### PR TITLE
Update python.sls, fixes template context error

### DIFF
--- a/postgres/python.sls
+++ b/postgres/python.sls
@@ -3,4 +3,4 @@
 postgresql-python:
   pkg:
     - installed
-    - name: {{ postgresql.python}}
+    - name: {{ postgres.python }}


### PR DESCRIPTION
was throwing an error due to absence of 'postgresql' in template context.
