### PR TITLE
update map.jinja Debian grain for postgresql 9.3

### DIFF
--- a/postgres/map.jinja
+++ b/postgres/map.jinja
@@ -1,9 +1,9 @@
 {% set postgres = salt['grains.filter_by']({
     'Debian': {
-        'pkg': 'postgresql-9.1',
+        'pkg': 'postgresql-9.3',
         'python': 'python-pygresql',
         'service': 'postgresql',
-        'pg_hba': '/etc/postgresql/9.1/main/pg_hba.conf',
+        'pg_hba': '/etc/postgresql/9.3/main/pg_hba.conf',
     },
     'RedHat': {
         'pkg': 'postgresql',


### PR DESCRIPTION
Formula was broken when not using pillar data. Fixed!

Version has a parameter should be next.
