### PR TITLE
Adding PostgreSQL 9.3 support for Ubuntu 14.04

### DIFF
--- a/postgres/init.sls
+++ b/postgres/init.sls
@@ -10,7 +10,7 @@ create-postgresql-cluster:
   cmd.run:
     - cwd: /
     - user: root
-    - name: pg_createcluster 9.3 main --start
+    - name: pg_createcluster {{ postgres.version }} main --start
     - unless: test -f {{ postgres.conf_dir }}/postgresql.conf
     - env:
       LC_ALL: C.UTF-8

--- a/postgres/map.jinja
+++ b/postgres/map.jinja
@@ -8,6 +8,7 @@
         'conf_dir': '/etc/postgresql/9.1/main',
         'create_cluster': False,
         'init_db': False,
+        'version': '9.1',
     },
     'RedHat': {
         'pkg': 'postgresql-server',
@@ -18,6 +19,7 @@
         'conf_dir': '/var/lib/pgsql/data',
         'create_cluster': False,
         'init_db': True,
+        'version': '9.1',
     },
     'Arch': {
         'pkg': 'postgresql',
@@ -28,6 +30,7 @@
         'conf_dir': '/var/lib/pgsql/data/',
         'create_cluster': False,
         'init_db': False,
+        'version': '9.1',
     },
 }, merge=salt['grains.filter_by']({
     '14.04': {
@@ -36,5 +39,6 @@
         'conf_dir': '/etc/postgresql/9.3/main',
         'service': 'postgresql',
         'create_cluster': True,
+        'version': '9.3',
     },
 }, grain='lsb_distrib_release', merge=salt['pillar.get']('postgres:lookup'))) %}


### PR DESCRIPTION
- Added conditional support for PostgreSQL 9.3.
- Added conf_dir and create_cluster variables to denote actions based on
  OS / release.
- Renamed the service to "postgresql-server" for CentOS / RHEL.
- Conditionally running "service postgresql initdb" for CentOS / RHEL.
- Made the devel packages variable, based on os_family.

I've updated map.jinja to provide access to postgres 9.3, but only if you're on Ubuntu 14.04. I've tested this with both Ubuntu 14.04 and Ubuntu 12.04, and there doesn't seem to be any regression.
