### PR TITLE
Add support for Debian 7 and Debian 8

### DIFF
--- a/postgres/map.jinja
+++ b/postgres/map.jinja
@@ -51,7 +51,7 @@
         'init_db': False,
         'version': '9.4',
     },
-        'wheezy': {
+    'wheezy': {
         'pkg': 'postgresql-9.1',
         'pkg_dev': 'postgresql-server-dev-9.1',
         'pkg_libpq_dev': 'libpq-dev',


### PR DESCRIPTION
To support different Debian releases with different major.minor versions, filtering by codename is the best method for Debian. Minor versions have no impact on the availability of postgres versions. Some versions are, however, not available between major releases.
