### PR TITLE
Limitation of default access rights to improve security

### DIFF
--- a/postgres/pg_hba.conf
+++ b/postgres/pg_hba.conf
@@ -24,8 +24,8 @@ local   all             postgres                                peer
 
 
 # "local" is for Unix domain socket connections only
-local   all             all                                     trust
+local   all             all                                     peer
 # IPv4 local connections:
-host    all             all             127.0.0.1/32            trust
+host    all             all             127.0.0.1/32            md5
 # IPv6 local connections:
-host    all             all             ::1/128                 trust
+host    all             all             ::1/128                 md5


### PR DESCRIPTION
Socket and localhost (IPv4 and IPv6) are set to trust. All users (except postgres) connecting from localhost and socket can authenticate without password.

This pull request sets more restrictive default methods, requesting password authentication for localhost and peer for socket. Permissive access can be granted by pillar.
