### PR TITLE
changed pg_hba.conf management-state precondition

### DIFF
--- a/postgres/init.sls
+++ b/postgres/init.sls
@@ -55,7 +55,7 @@ postgresql-conf:
        - service: postgresql
 {% endif %}
 
-{% if 'pg_hba.conf' in pillar.get('postgres', {}) %}
+{% if 'acls' in pillar.get('postgres', {}) %}
 pg_hba.conf:
   file.managed:
     - name: {{ postgres.conf_dir }}/pg_hba.conf


### PR DESCRIPTION
For me the default behavior of this formula is a bit strange. 
It took me some time to see that the pg_hba-file is not managed if no "pg_hba.conf"-item is given. 

I would suggest to change this to check if ACLs exists or at least write a note into the docs.

PS: Thanks for this Formula, it (after all) saved me a lot of time.