### PR TITLE
Add option to use upstream repo on Debian

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,8 @@
 postgres:
   pg_hba.conf: salt://postgres/pg_hba.conf
 
+  use_upstream_repo: True
+
   lookup:
     pkg: 'postgresql-9.3'
     pg_hba: '/etc/postgresql/9.3/main/pg_hba.conf'

--- a/postgres/init.sls
+++ b/postgres/init.sls
@@ -1,8 +1,21 @@
 {% from "postgres/map.jinja" import postgres with context %}
 
+{% if 'use_upstream_repo' in pillar.get('postgres') %}
+install-postgresql-repo:
+  pkgrepo.managed:
+    - humanname: PostgreSQL Official Repository
+    - name: {{ postgres.pkg_repo }}
+    - keyid: B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
+    - keyserver: keyserver.ubuntu.com
+    - file: {{ postgres.pkg_repo_file }}
+    - require_in:
+        - install-postgresql
+{% endif %}
+
 install-postgresql:
   pkg.installed:
     - name: {{ postgres.pkg }}
+    - refresh: {{ 'use_upstream_repo' in pillar.get('postgres') }}
 
 {% if postgres.create_cluster != False %}
 create-postgresql-cluster:

--- a/postgres/map.jinja
+++ b/postgres/map.jinja
@@ -34,9 +34,11 @@
         'version'        : pg_version.id,
     },
     'Debian': {
-        'pkg'            : 'postgresql',
+        'pkg'            : 'postgresql-' + pg_version.id,
         'pkg_dev'        : 'postgresql-server-dev-' + pg_version.id,
         'pkg_libpq_dev'  : 'libpq-dev',
+        'pkg_repo'       : 'deb http://apt.postgresql.org/pub/repos/apt/ ' + grains['lsb_distrib_codename'] + '-pgdg main',
+        'pkg_repo_file'  : '/etc/apt/sources.list.d/pgdg.list',
         'python'         : 'python-pygresql',
         'service'        : 'postgresql',
         'pg_hba'         : '/etc/postgresql/' + pg_version.id + '/main/pg_hba.conf',


### PR DESCRIPTION
This allows Debian users to use the official PostgreSQL repository, allowing the installation of versions not provided by their distribution repository.

Note that the _postgres_ package just pulls in the latest version, which is why I added the suffix to `pkg`. Otherwise `9.4` would be installed and the formula would expect its configuration in the `9.1` folder (on _wheezy_ anyway). To actually use a different version, `postgres.lookup.id` needs to be set to `'9.4'` or similar. Otherwise the formula will just install the distribution-default version.

Should be pretty easy to adapt for other APT/RPM distributions (that's all `salt.states.pkgrepo` supports) by following the [PostgreSQL distribution-specific instructions](http://docs.saltstack.com/en/latest/ref/states/all/salt.states.pkgrepo.html), but I don't have any such boxen to test with.