### PR TITLE
Add switch to install contrib package

### DIFF
--- a/postgres/init.sls
+++ b/postgres/init.sls
@@ -58,6 +58,12 @@ install-postgres-libpq-dev:
     - name: {{ postgres.pkg_libpq_dev }}
 {% endif %}
 
+{% if postgres.pkg_contrib != False %}
+install-postgres-contrib:
+  pkg.installed:
+    - name: {{ postgres.pkg_contrib }}
+{% endif %}
+
 {% if 'postgresconf' in pillar.get('postgres', {}) %}
 postgresql-conf:
   file.blockreplace:

--- a/postgres/map.jinja
+++ b/postgres/map.jinja
@@ -37,6 +37,7 @@
         'pkg'            : 'postgresql-' + pg_version.id,
         'pkg_dev'        : 'postgresql-server-dev-' + pg_version.id,
         'pkg_libpq_dev'  : 'libpq-dev',
+        'pkg_contrib'    : 'postgresql-contrib-' + pg_version.id,
         'pkg_repo'       : 'deb http://apt.postgresql.org/pub/repos/apt/ ' + grains['lsb_distrib_codename'] + '-pgdg main',
         'pkg_repo_file'  : '/etc/apt/sources.list.d/pgdg.list',
         'python'         : 'python-pygresql',


### PR DESCRIPTION
I've checked on debian and the _postgres-contrib_ package exists for both the debian and official versions, so it's fine whichever is used.