### PR TITLE
allow multiline postgres:postgresconf

### DIFF
--- a/postgres/init.sls
+++ b/postgres/init.sls
@@ -70,7 +70,8 @@ postgresql-conf:
     - name: {{ postgres.conf_dir }}/postgresql.conf
     - marker_start: "# Managed by SaltStack: listen_addresses: please do not edit"
     - marker_end: "# Managed by SaltStack: end of salt managed zone --"
-    - content: {{ salt['pillar.get']('postgres:postgresconf') }}
+    - content: |
+        {{ salt['pillar.get']('postgres:postgresconf') | indent(8) }}
     - show_changes: True
     - append_if_not_found: True
     - watch_in:


### PR DESCRIPTION
Added automatic indentation of postgres:postgresconf to allow for multiple lines to be added to the conf as per https://github.com/saltstack/salt/pull/5920