### PR TITLE
Fix backward compat

### DIFF
--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -14,5 +14,6 @@ postgres:
   users: {}
   acls: []
   databases: {}
+  tablespaces: {}
   postgresconf: ""
   pg_hba.conf: salt://postgres/pg_hba.conf


### PR DESCRIPTION
This should fix the backwards compatibility breakage. Missed in my testing
because I had a pre-existing pillar setup (from an old way I did tablespace
support).

Fixes #48 