### PR TITLE
Fix __salt__ unavailable in __virtual__()

### DIFF
--- a/_modules/postgres_ext.py
+++ b/_modules/postgres_ext.py
@@ -16,7 +16,7 @@ def __virtual__():
     '''
     Only load this module if the postgres module is already loaded
     '''
-    if 'postgres.psql_query' in __salt__:
+    if all((salt.utils.which('psql'), HAS_ALL_IMPORTS)):
         return True
     return False
 


### PR DESCRIPTION
In older versions of Salt (this was originally developed against 2015.2),
__salt__ isn't loaded yet in the __virtual__() function. Work around this by
just duplicating the check from upstream postgres.py

Fixes #52 