### PR TITLE
Add support for database extensions.

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -38,14 +38,18 @@ postgres:
       template: 'template0'
       lc_ctype: 'C.UTF-8'
       lc_collate: 'C.UTF-8'
-
+      # optional extensions to enable on database
+      extensions:
+        - uuid-ossp
     db2:
       owner: 'localUser'
       user: 'remoteUser'
       template: 'template0'
       lc_ctype: 'C.UTF-8'
       lc_collate: 'C.UTF-8'
-
+      # optional extensions to enable on database
+      extensions:
+        - postgis
   # This section will append your configuration to postgresql.conf.
   postgresconf: |
     listen_addresses = 'localhost,*'

--- a/postgres/init.sls
+++ b/postgres/init.sls
@@ -103,6 +103,16 @@ postgres-db-{{ name }}:
     - require:
         - postgres_user: postgres-user-{{ db.get('user') }}
     {% endif %}
+
+{% if db.extensions is defined %}
+{% for ext in db.extensions %}
+postgres-ext-{{ ext }}-for-db-{{ name }}:
+  postgres_extension.present:
+    - name: {{ ext }}
+    - user: {{ db.get('runas', 'postgres') }}
+    - maintenance_db: {{ name }}
+{% endfor %}
+{% endif %}
 {% endfor%}
 
 {% for name, directory in postgres.tablespaces.items()  %}


### PR DESCRIPTION
This commit adds support for database extensions via
`salt.states.postgres_extension.present` http://docs.saltstack.com/en/latest/ref/states/all/salt.states.postgres_extension.html#management-of-postgresql-extensions-e-g-postgis

When configuring database pillar data all you need to do is add (optional)
extension list with the extensions that you want the state to apply to specific
database. Example:

    db1:
      owner: 'localUser'
      user: 'localUser'
      template: 'template0'
      lc_ctype: 'C.UTF-8'
      lc_collate: 'C.UTF-8'
      extensions:
        - uuid-ossp

This will make sure `uuid-ossp` extension is enabled on `db1` database.

Updated pillar.example to include (optional) extensions