### PR TITLE
Moving initdb command definition

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,5 +1,7 @@
 postgres:
   pg_hba.conf: salt://postgres/pg_hba.conf
+  commands:
+    initdb: service postgresql initdb
 
   use_upstream_repo: False
 

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -17,3 +17,5 @@ postgres:
   tablespaces: {}
   postgresconf: ""
   pg_hba.conf: salt://postgres/pg_hba.conf
+  commands:
+    initdb: service postgresql initdb

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -5,5 +5,3 @@ Arch: {}
 Debian:
   pkg_repo_file: /etc/apt/sources.list.d/pgdg.list
   pkg_libpq_dev: libpq-dev
-  commands:
-    initdb: service postgresql initdb


### PR DESCRIPTION
Fix for the previously incomplete PR-- I mistakenly thought that Debian-based distros were the only ones that would continue to support `service postgresql initdb`. @iggy's point is totally valid, for backwards compatibility though, so I'm moving it into `defaults`. Also wrapping things up by adding an example to `pillar.example`.