### PR TITLE
Add missing conf_dir for Ubuntu Codenames.

### DIFF
--- a/postgres/codenamemap.yaml
+++ b/postgres/codenamemap.yaml
@@ -10,9 +10,12 @@ jessie:
 trusty:
   version: 9.3
   pkg_repo: deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main
+  conf_dir: /etc/postgresql/9.3/main
 utopic:
   version: 9.4
   pkg_repo: deb http://apt.postgresql.org/pub/repos/apt/ utopic-pgdg main
+  conf_dir: /etc/postgresql/9.4/main
 vivid:
   version: 9.4
   pkg_repo: deb http://apt.postgresql.org/pub/repos/apt/ utopic-pgdg main
+  conf_dir: /etc/postgresql/9.4/main


### PR DESCRIPTION
Hi,

Default distribution conf_dirs were missing for Ubuntu codenames.

Sincerely,