### PR TITLE
Add postgresql overrides for CentOS 6/7

### DIFF
--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -1,4 +1,9 @@
 RedHat:
+  init_db: True
+  commands:
+    initdb: sudo -u postgres initdb /var/lib/pgsql/data
+  pkg: postgresql-server
+  pkg_client: postgresql
   pkg_repo: pgdg94
   repo_baseurl: http://yum.postgresql.org/9.4/redhat/rhel-$releasever-$basearch
 Arch: {}


### PR DESCRIPTION
Added postgresql overrides for CentOS 6/7. Fixes #63.
Tested on CentOS 7. Verified package names for CentOS 6.