### PR TITLE
Upstream repo for RedHat

### DIFF
--- a/postgres/upstream.sls
+++ b/postgres/upstream.sls
@@ -12,3 +12,19 @@ install-postgresql-repo:
       - pkg: install-postgresql
 {% endif %}
 
+{% if grains['os_family'] == 'RedHat' %}
+install-postgresql-repo:
+  file.managed:
+    - name: /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG
+    - source: https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+    - source_hash: md5=78b5db170d33f80ad5a47863a7476b22
+  pkgrepo.managed:
+    - name: pgdg-{{ postgres.version }}-centos
+    - order: 1
+    - humanname: PostgreSQL {{ postgres.version }} $releasever - $basearch
+    - baseurl: https://download.postgresql.org/pub/repos/yum/{{ postgres.version }}/redhat/rhel-$releasever-$basearch
+    - gpgcheck: 1
+    - gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG
+    - require:
+      - file: install-postgresql-repo
+{% endif %}


### PR DESCRIPTION
This adds the the official yum repo and GPG key.
The source_hash for the GPG key is hardcoded, but this can be updated if psql decide to renew their keys!