### PR TITLE
Added option to disable creation of backup file when postgresql.conf …

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -71,6 +71,9 @@ postgres:
       # optional extensions to enable on database
       extensions:
         postgis:
+  # backup extension defaults to .bak if postgresconf_backup is True.
+  # Set to False to stop creation of backup on postgresql.conf changes.
+  postgresconf_backup: True
   # This section will append your configuration to postgresql.conf.
   postgresconf: |
     listen_addresses = 'localhost,*'

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -15,6 +15,7 @@ postgres:
   acls: []
   databases: {}
   tablespaces: {}
+  postgresconf_backup: True
   postgresconf: ""
   pg_hba.conf: salt://postgres/pg_hba.conf
   commands:

--- a/postgres/init.sls
+++ b/postgres/init.sls
@@ -59,6 +59,9 @@ postgresql-conf:
         {{ postgres.postgresconf|indent(8) }}
     - show_changes: True
     - append_if_not_found: True
+    {% if not postgres.postgresconf_backup|default(True) -%}
+    - backup: False
+    {% endif -%}
     - watch_in:
        - service: run-postgresql
 {% endif %}


### PR DESCRIPTION
Added postgresconf_backup option which allows disabling of .bak file creation for postgresql.conf when it changes.
Due to fopen issue with file.blockreplace - .bak file is currently created with root:root ownership - which causes downstream issues with wal-e backup-push and messes around with IDS.
Default behaviour doesn't change - file is backed up unless explicitly configured otherwise.