### PR TITLE
Reload postgresql server instead of restarting it

### DIFF
--- a/postgres/init.sls
+++ b/postgres/init.sls
@@ -40,7 +40,8 @@ postgresql-initdb:
 
 run-postgresql:
   service.running:
-    - enable: true
+    - enable: True
+    - reload: True
     - name: {{ postgres.service }}
     - require:
       - pkg: install-postgresql


### PR DESCRIPTION
Fixes #91

In case of changes in postgresql.conf and pg_hba.conf the
postgresql will now reload instead of restart.