### PR TITLE
Allow initdb to be run as other users, cleanup of dependencies

### DIFF
--- a/_modules/postgres_ext.py
+++ b/_modules/postgres_ext.py
@@ -33,13 +33,6 @@ def _run_psql(cmd, runas=None, password=None, host=None, port=None, user=None):
     if runas is None:
         if not host:
             host = __salt__['config.option']('postgres.host')
-        if not host or host.startswith('/'):
-            if 'FreeBSD' in __grains__['os_family']:
-                runas = 'pgsql'
-            if 'OpenBSD' in __grains__['os_family']:
-                runas = '_postgresql'
-            else:
-                runas = 'postgres'
 
     if user is None:
         user = runas

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -20,5 +20,6 @@ postgres:
   pg_hba.conf: salt://postgres/pg_hba.conf
   commands:
     initdb: service postgresql initdb
-  postgres_user: postgres
-  postgres_group: postgres
+  initdb_user: root
+  user: postgres
+  group: postgres

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -7,7 +7,7 @@ postgres:
   python: python-psycopg2
   service: postgresql
   conf_dir: /var/lib/pgsql/data
-  runtime_dir: /var/lib/pgsql/data
+  data_dir: /var/lib/pgsql/data
   create_cluster: False
   init_db: False
   version: 9.1

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -7,6 +7,7 @@ postgres:
   python: python-psycopg2
   service: postgresql
   conf_dir: /var/lib/pgsql/data
+  runtime_dir: /var/lib/pgsql/data
   create_cluster: False
   init_db: False
   version: 9.1
@@ -21,5 +22,6 @@ postgres:
   commands:
     initdb: service postgresql initdb
   initdb_user: root
+  initdb_args: --data-checksum
   user: postgres
   group: postgres

--- a/postgres/init.sls
+++ b/postgres/init.sls
@@ -7,8 +7,8 @@ include:
 
 {{ postgres.conf_dir }}:
   file.directory:
-    - user: {{ postgres.postgres_user }}
-    - group: {{ postgres.postgres_group }}
+    - user: {{ postgres.user }}
+    - group: {{ postgres.group }}
     - makedirs: True
 
 install-postgresql:
@@ -31,7 +31,7 @@ create-postgresql-cluster:
 postgresql-initdb:
   cmd.run:
     - cwd: /
-    - user: root
+    - user: {{ postgres.initdb_user }}
     - name: {{ postgres.commands.initdb }}
     - unless: test -f {{ postgres.conf_dir }}/postgresql.conf
     - env:
@@ -73,8 +73,8 @@ pg_hba.conf:
     - name: {{ postgres.conf_dir }}/pg_hba.conf
     - source: {{ postgres['pg_hba.conf'] }}
     - template: jinja
-    - user: {{ postgres.postgres_user }}
-    - group: {{ postgres.postgres_group }}
+    - user: {{ postgres.user }}
+    - group: {{ postgres.group }}
     - mode: 644
     - require:
       - pkg: install-postgresql
@@ -93,14 +93,14 @@ postgres-user-{{ name }}:
     - inherit: {{ user.get('inherit', True) }}
     - replication: {{ user.get('replication', False) }}
     - password: {{ user.get('password', 'changethis') }}
-    - user: {{ user.get('runas', postgres.postgres_user) }}
+    - user: {{ user.get('runas', postgres.user) }}
     - superuser: {{ user.get('superuser', False) }}
     - require:
       - service: run-postgresql
 {% else %}
   postgres_user.absent:
     - name: {{ name }}
-    - user: {{ user.get('runas', postgres.postgres_user) }}
+    - user: {{ user.get('runas', postgres.user) }}
     - require:
       - service: run-postgresql
 {% endif %}
@@ -117,7 +117,7 @@ postgres-db-{{ name }}:
     {% if db.get('owner') %}
     - owner: {{ db.get('owner') }}
     {% endif %}
-    - user: {{ db.get('runas', postgres.postgres_user) }}
+    - user: {{ db.get('runas', postgres.user) }}
     - require:
         - service: run-postgresql
     {% if db.get('user') %}
@@ -143,7 +143,7 @@ postgres-schema-{{ schema }}-for-db-{{ name }}:
 postgres-ext-{{ ext }}-for-db-{{ name }}:
   postgres_extension.present:
     - name: {{ ext }}
-    - user: {{ db.get('runas', postgres.postgres_user) }}
+    - user: {{ db.get('runas', postgres.user) }}
     - maintenance_db: {{ name }}
 {% if ext_args is not none %}
 {% for arg, value in ext_args.items() %}

--- a/postgres/init.sls
+++ b/postgres/init.sls
@@ -32,8 +32,8 @@ postgresql-initdb:
   cmd.run:
     - cwd: /
     - user: {{ postgres.initdb_user }}
-    - name: {{ postgres.commands.initdb }}
-    - unless: test -f {{ postgres.conf_dir }}/postgresql.conf
+    - name: {{ postgres.commands.initdb }} {{ postgres.initdb_args }} -D {{ postgres.runtime_dir }}
+    - unless: test -f {{ postgres.runtime_dir }}/PG_VERSION
     - env:
       LC_ALL: C.UTF-8
 {% endif %}

--- a/postgres/init.sls
+++ b/postgres/init.sls
@@ -32,8 +32,8 @@ postgresql-initdb:
   cmd.run:
     - cwd: /
     - user: {{ postgres.initdb_user }}
-    - name: {{ postgres.commands.initdb }} {{ postgres.initdb_args }} -D {{ postgres.runtime_dir }}
-    - unless: test -f {{ postgres.runtime_dir }}/PG_VERSION
+    - name: {{ postgres.commands.initdb }} {{ postgres.initdb_args }} -D {{ postgres.data_dir }}
+    - unless: test -f {{ postgres.data_dir }}/PG_VERSION
     - env:
       LC_ALL: C.UTF-8
 {% endif %}

--- a/postgres/map.jinja
+++ b/postgres/map.jinja
@@ -3,7 +3,7 @@
 {% import_yaml "postgres/codenamemap.yaml" as codemap %}
 
 {# get the settings for the os_family grain #}
-{% set osfam = salt['grains.filter_by'](osmap) or {} %}
+{% set osfam = salt['grains.filter_by'](osmap, grain='os_family') or {} %}
 {# get the settings for the oscodename grain, os_family data will override
     oscodename data #}
 {% set oscode = salt['grains.filter_by'](codemap,

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -1,7 +1,8 @@
 RedHat:
   init_db: True
   commands:
-    initdb: initdb /var/lib/pgsql/data
+    initdb: initdb
+  initdb_user: postgres
   pkg: postgresql-server
   pkg_client: postgresql
   pkg_repo: pgdg94
@@ -11,8 +12,10 @@ Debian:
   pkg_repo_file: /etc/apt/sources.list.d/pgdg.list
   pkg_libpq_dev: libpq-dev
 Suse:
+  init_db: True
   commands:
-    initdb: initdb /var/lib/pgsql/data
+    initdb: initdb
+  initdb_user: postgres
   pkg: postgresql-server
   pkg_client: postgresql
 FreeBSD:

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -1,7 +1,7 @@
 RedHat:
   init_db: True
   commands:
-    initdb: sudo -u postgres initdb /var/lib/pgsql/data
+    initdb: initdb /var/lib/pgsql/data
   pkg: postgresql-server
   pkg_client: postgresql
   pkg_repo: pgdg94
@@ -12,6 +12,10 @@ Debian:
   pkg_libpq_dev: libpq-dev
 Suse:
   commands:
-    initdb: sudo -u postgres initdb /var/lib/pgsql/data
+    initdb: initdb /var/lib/pgsql/data
   pkg: postgresql-server
   pkg_client: postgresql
+FreeBSD:
+  user: pgsql
+OpenBSD:
+  user: _postgresql


### PR DESCRIPTION
- Allow initdb to be run as other users besides root
- All states now start with postgres-<thing> 
- Cleanup of dependencies
- Abstracted cluster initialization
- Invert the tests for user and db creation and dropping so it matches on absent exactly
- Extensions and schemas are wrapped inside the logic for db creation. This prevents trying to create extensions and schemas for a database that you are trying to drop.
- Tested on centos 7 and ubuntu 14.04 docker images.