### PR TITLE
Allow to specify a tablespace for databases

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,9 +6,9 @@ driver:
 
 provisioner:
   name: salt_solo
+  data_path: test/shared
+  salt_install: bootstrap
   formula: postgres
-  pillars-from-files:
-    postgres.sls: pillar.example
   pillars:
     top.sls:
       base:
@@ -19,8 +19,44 @@ provisioner:
       "*":
         - postgres
 
-platforms:
-  - name: ubuntu-14.04
-
 suites:
   - name: default
+
+platforms:
+  - name: ubuntu-14.04
+    provisioner:
+      pillars:
+        postgres.sls:
+          postgres:
+            lookup:
+              pkgs_extra:
+                - 'postgresql-contrib' 
+              pg_hba: '/etc/postgresql/9.3/main/pg_hba.conf'
+            users:
+              remoteUser:
+                ensure: present
+                password: '98ruj923h4rf'
+            databases:
+              db1:
+                owner: 'remoteUser'
+                tablespace: 'my_space'
+            tablespaces:
+              my_space: '/srv/my_tablespace'
+
+  - name: centos-7
+    driver_config:
+      box: rchrd/centos-7-x64-salt
+    provisioner:
+      pillars:
+        postgres.sls:
+          postgres:
+            lookup:
+              pkg: 'postgresql-server'
+              pkg_client: 'postgresql-client'
+              pg_hba: '/etc/postgresql/9.2/main/pg_hba.conf'
+            commands:
+              initdb: 'postgresql-setup initdb'
+            initdb_args: ''
+            initdb_user: 'root'
+            tablespaces:
+              my_space: '/srv/my_tablespace'

--- a/pillar.example
+++ b/pillar.example
@@ -47,6 +47,9 @@ postgres:
     - ['local', 'db1', 'localUser']
     - ['host', 'db2', 'remoteUser', '123.123.0.0/24']
 
+  tablespaces:
+    my_space: /srv/my_tablespace
+
   databases:
     db1:
       owner: 'localUser'
@@ -68,9 +71,10 @@ postgres:
       template: 'template0'
       lc_ctype: 'C.UTF-8'
       lc_collate: 'C.UTF-8'
+      tablespace: '/srv/my_tablespace'
       # optional extensions to enable on database
-      extensions:
-        postgis:
+      # extensions:
+      #   postgis:
   # backup extension defaults to .bak if postgresconf_backup is True.
   # Set to False to stop creation of backup on postgresql.conf changes.
   postgresconf_backup: True

--- a/postgres/init.sls
+++ b/postgres/init.sls
@@ -9,6 +9,37 @@ postgresql-installed:
   pkg.installed:
     - name: {{ postgres.pkg }}
     - refresh: {{ postgres.use_upstream_repo }}
+    - require_in:
+      - file: postgresql-config-dir
+
+# make sure the data directory and contents have been initialized
+{% if postgres.create_cluster %}
+  {%- set cluster_cmd = 'pg_createcluster ' ~ postgres.version  ~ 'main' %}
+  {%- set cluster_test = 'test -f ' ~ postgres.conf_dir ~ '/environment' %}
+  {%- set cluster_user = 'root' %}
+{% endif %}
+
+{% if postgres.init_db %}
+  {%- set cluster_cmd = postgres.commands.initdb ~ ' ' ~ postgres.initdb_args %}
+  {%- set cluster_test = 'test -f ' ~ postgres.data_dir ~ '/PG_VERSION' %}
+  {%- set cluster_user = postgres.initdb_user %}
+{% endif %}
+
+{% if postgres.create_cluster or postgres.init_db %}
+postgresql-create-cluster:
+  cmd.run:
+    - cwd: /
+    - user: {{ cluster_user }}
+    - name: {{ cluster_cmd }}
+    - unless:
+      - {{ cluster_test }}
+    - require:
+      - pkg: postgresql-installed
+    - require_in:
+      - file: postgresql-config-dir
+    - env:
+      LC_ALL: C.UTF-8
+{% endif %}
 
 postgresql-config-dir:
   file.directory:
@@ -16,29 +47,6 @@ postgresql-config-dir:
     - user: {{ postgres.user }}
     - group: {{ postgres.group }}
     - makedirs: True
-    - require:
-      - cmd: postgresql-installed
-
-# make sure the data directory and contents have been initialized
-{% if postgres.create_cluster != False %}
-postgresql-cluster-prepared:
-  cmd.run:
-    - cwd: /
-    - user: root
-    - name: pg_createcluster {{ postgres.version }} main
-    - unless:
-      - test -f {{ postgres.conf_dir }}/environment
-{% endif %}
-{% if postgres.init_db != False %}
-    - user: {{ postgres.initdb_user }}
-    - name: {{ postgres.commands.initdb }} {{ postgres.initdb_args }} -D {{ postgres.data_dir }}
-    - unless:
-      - test -f {{ postgres.data_dir }}/PG_VERSION
-{% endif %}
-    - require:
-      - pkg: postgresql-installed
-    - env:
-      LC_ALL: C.UTF-8
 
 postgresql-running:
   service.running:
@@ -111,6 +119,27 @@ postgresql-user-{{ name }}:
       - service: postgresql-running
 {% endfor %}
 
+{% for name, directory in postgres.tablespaces.items()  %}
+postgresql-tablespace-dir-perms-{{ directory}}:
+  file.directory:
+    - name: {{ directory }}
+    - user: postgres
+    - group: postgres
+    - makedirs: True
+    - recurse:
+      - user
+      - group
+
+postgresql-tablespace-{{ name }}:
+  postgres_tablespace.present:
+    - name: {{ name }}
+    - directory: {{ directory }}
+    - user: postgres
+    - require:
+      - service: postgresql-running
+      - file: postgresql-tablespace-dir-perms-{{ directory}}
+{% endfor %}
+
 {% for name, db in postgres.databases.items()  %}
 postgresql-db-{{ name }}:
 {% if db.get('ensure', 'present') == 'absent' %}
@@ -125,6 +154,7 @@ postgresql-db-{{ name }}:
     - lc_ctype: {{ db.get('lc_ctype', 'en_US.UTF8') }}
     - lc_collate: {{ db.get('lc_collate', 'en_US.UTF8') }}
     - template: {{ db.get('template', 'template0') }}
+    - tablespace: {{ db.get('tablespace', 'pg_default') }}
     {% if db.get('owner') %}
     - owner: {{ db.get('owner') }}
     {% endif %}
@@ -168,26 +198,5 @@ postgresql-ext-{{ ext }}-for-db-{{ name }}:
 {% endfor %}
 {% endif %}
 {% endif %}
-{% endfor %}
-
-
-{% for name, directory in postgres.tablespaces.items()  %}
-postgresql-tablespace-dir-perms-{{ directory}}:
-  file.directory:
-    - name: {{ directory }}
-    - user: postgres
-    - group: postgres
-    - makedirs: True
-    - recurse:
-      - user
-      - group
-
-postgresql-tablespace-{{ name }}:
-  postgres_tablespace.present:
-    - name: {{ name }}
-    - directory: {{ directory }}
-    - require:
-      - service: postgresql-running
-      - file: postgresql-tablespace-dir-perms-{{ directory}}
 {% endfor %}
 

--- a/test/integration/default/serverspec/postgres_spec.rb
+++ b/test/integration/default/serverspec/postgres_spec.rb
@@ -1,10 +1,17 @@
 require "serverspec"
 
-describe service("postgres") do
+describe service("postgresql") do
   it { should be_enabled }
   it { should be_running }
 end
 
 describe port("5432") do
   it { should be_listening }
+end
+
+describe file("/srv/my_tablespace") do
+  it { should be_directory }
+  it { should be_mode 755 }
+  it { should be_owned_by "postgres" }
+  it { should be_grouped_into "postgres" }
 end

--- a/test/integration/default/serverspec/postgres_spec.rb
+++ b/test/integration/default/serverspec/postgres_spec.rb
@@ -1,4 +1,4 @@
-require "serverspec"
+require_relative '../../../kitchen/data/spec_helper'
 
 describe service("postgresql") do
   it { should be_enabled }
@@ -11,7 +11,7 @@ end
 
 describe file("/srv/my_tablespace") do
   it { should be_directory }
-  it { should be_mode 755 }
+  it { should be_mode 700 }
   it { should be_owned_by "postgres" }
   it { should be_grouped_into "postgres" }
 end

--- a/test/shared/spec_helper.rb
+++ b/test/shared/spec_helper.rb
@@ -1,0 +1,9 @@
+require "serverspec"
+require "pathname"
+
+# Set backend type
+set :backend, :exec
+
+RSpec.configure do |c|
+  c.path = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+end


### PR DESCRIPTION
* Also, tablespaces need to exist beforehand
* config_dir just needs the package to be installed
* Add tablespace example to the pillar
* postgresql-cluster-prepared fails as it's not a valid cmd. Fixed
* Fix tests