### PR TITLE
Fix broken Arch initdb from merge of PR#101

### DIFF
--- a/postgres/codenamemap.yaml
+++ b/postgres/codenamemap.yaml
@@ -3,45 +3,37 @@ precise:
   pkg_repo: deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main
   conf_dir: /etc/postgresql/9.4/main
   data_dir: /var/lib/postgresql/9.4/main
-  pkg_dev: postgresql-server-dev-9.4
 wheezy:
   pkg_repo: deb http://apt.postgresql.org/pub/repos/apt/ wheezy-pgdg main
   conf_dir: /etc/postgresql/9.1/main
   data_dir: /var/lib/postgresql/9.1/main
-  pkg_dev: postgresql-server-dev-9.1
 jessie:
   version: 9.4
   pkg_repo: deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main
   conf_dir: /etc/postgresql/9.4/main
   data_dir: /var/lib/postgresql/9.4/main
-  pkg_dev: postgresql-server-dev-9.4
 trusty:
   version: 9.3
   pkg_repo: deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main
   conf_dir: /etc/postgresql/9.3/main
   data_dir: /var/lib/postgresql/9.3/main
-  pkg_dev: postgresql-server-dev-9.3
 utopic:
   version: 9.4
   pkg_repo: deb http://apt.postgresql.org/pub/repos/apt/ utopic-pgdg main
   conf_dir: /etc/postgresql/9.4/main
   data_dir: /var/lib/postgresql/9.4/main
-  pkg_dev: postgresql-server-dev-9.4
 vivid:
   version: 9.4
   pkg_repo: deb http://apt.postgresql.org/pub/repos/apt/ utopic-pgdg main
   conf_dir: /etc/postgresql/9.4/main
   data_dir: /var/lib/postgresql/9.4/main
-  pkg_dev: postgresql-server-dev-9.4
 wily:
   version: 9.4
   pkg_repo: deb http://apt.postgresql.org/pub/repos/apt/ wily-pgdg main
   conf_dir: /etc/postgresql/9.4/main
   data_dir: /var/lib/postgresql/9.4/main
-  pkg_dev: postgresql-server-dev-9.4
 xenial:
   version: 9.5
   pkg_repo: deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main
   conf_dir: /etc/postgresql/9.5/main
   data_dir: /var/lib/postgresql/9.5/main
-  pkg_dev: postgresql-server-dev-9.5

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -8,8 +8,6 @@ postgres:
   service: postgresql
   conf_dir: /var/lib/pgsql/data
   data_dir: /var/lib/pgsql/data
-  create_cluster: False
-  init_db: False
   version: 9.1
   use_upstream_repo: False
   users: {}
@@ -19,9 +17,10 @@ postgres:
   postgresconf_backup: True
   postgresconf: ""
   pg_hba.conf: salt://postgres/pg_hba.conf
-  commands:
-    initdb: service postgresql initdb
+  initdb: True
   initdb_user: root
   initdb_args: --data-checksum
+  commands:
+    initdb: service postgresql initdb
   user: postgres
   group: postgres

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -17,6 +17,7 @@ Arch:
   pkg_dev: postgresql
 Debian:
   pkg_repo_file: /etc/apt/sources.list.d/pgdg.list
+  pkg_dev: postgresql-server-dev-all
   pkg_libpq_dev: libpq-dev
   initdb: False
 Suse:

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -10,8 +10,9 @@ Arch:
   conf_dir: /var/lib/postgres/data
   data_dir: /var/lib/postgres/data
   initdb_user: postgres
+  initdb_args: --locale en_US.UTF8 -E UTF8
   commands:
-    initdb: initdb --locale en_US.UTF8 -E UTF8 -D "/var/lib/postgres/data"
+    initdb: initdb
   pkg_client: postgresql
   pkg_dev: postgresql
 Debian:

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -1,8 +1,7 @@
 RedHat:
-  init_db: True
+  initdb_user: postgres
   commands:
     initdb: initdb
-  initdb_user: postgres
   pkg: postgresql-server
   pkg_client: postgresql
   pkg_repo: pgdg94
@@ -10,7 +9,6 @@ RedHat:
 Arch:
   conf_dir: /var/lib/postgres/data
   data_dir: /var/lib/postgres/data
-  init_db: True
   initdb_user: postgres
   commands:
     initdb: initdb --locale en_US.UTF8 -E UTF8 -D "/var/lib/postgres/data"
@@ -19,11 +17,11 @@ Arch:
 Debian:
   pkg_repo_file: /etc/apt/sources.list.d/pgdg.list
   pkg_libpq_dev: libpq-dev
+  initdb: False
 Suse:
-  init_db: True
+  initdb_user: postgres
   commands:
     initdb: initdb
-  initdb_user: postgres
   pkg: postgresql-server
   pkg_client: postgresql
 FreeBSD:


### PR DESCRIPTION
As discussed in #100, the state fooled me into thinking initdb created the database while it takes care of the cluster. The state provided two settings to select the method to create the cluster. I think it should be controlled by just one and since Debian has its specific tools just reflect that in the state.

If an admin of a Debian server wants to use initdb directly, it can still be done by setting `initdb: True` in `postgres:lookup`.

Also include a minor fix for `osmap` usage of Arch and a slightly less verbose `pkg_dev` setting for Debian family OS.