### PR TITLE
Remove python support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,11 +18,6 @@ Available states
 
 Installs the postgresql package.
 
-``postgres.python``
--------------------
-
-Installs the postgresql python module
-
 ``postgres.client``
 -------------------
 

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -4,7 +4,6 @@ postgres:
   pkg_libpq_dev: postgresql-libs
   pkg_client: postgresql-client
   pkgs_extra:
-  python: python-psycopg2
   service: postgresql
   conf_dir: /var/lib/pgsql/data
   data_dir: /var/lib/pgsql/data

--- a/postgres/python.sls
+++ b/postgres/python.sls
@@ -1,5 +1,0 @@
-{% from "postgres/map.jinja" import postgres with context %}
-
-postgresql-python:
-  pkg.installed:
-    - name: {{ postgres.python}}


### PR DESCRIPTION
In my opinion, the responsibilities of the postgres-formula should be to install the postgres server, client, and related packages (for example, postgres contrib modules). 

My feeling is that the formula is overstepping its boundaries by supporting the installation of python bindings, psycopg2, etc. If we do intend for this formula to continue supporting python, we should consider expanding this to also deal with ruby, perl, etc packages as well.