### PR TITLE
fixes formula to comply to its spec

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,12 +1,5 @@
 postgres:
   pg_hba.conf: salt://postgres/pg_hba.conf
-  prepare_cluster:
-    user: root
-    command: service postgresql initdb
-    test: test -f /path/to/some/file
-    env:
-      LC_ALL: en_US.UTF-8
-
   use_upstream_repo: False
 
   pkg: 'postgresql-9.3'
@@ -50,12 +43,13 @@ postgres:
     - ['host', 'db2', 'remoteUser', '123.123.0.0/24']
 
   tablespaces:
-    my_space: /srv/my_tablespace
+    my_space:
+      directory: /srv/my_tablespace
+      owner: localUser
 
   databases:
     db1:
       owner: 'localUser'
-      user: 'localUser'
       template: 'template0'
       lc_ctype: 'en_US.UTF-8'
       lc_collate: 'en_US.UTF-8'

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -3,7 +3,6 @@ postgres:
   pkg_dev: postgresql-devel
   pkg_libpq_dev: postgresql-libs
   pkg_client: postgresql-client
-  pkgs_extra:
   python: python-psycopg2
   service: postgresql
   conf_dir: /var/lib/pgsql/data

--- a/postgres/init.sls
+++ b/postgres/init.sls
@@ -48,9 +48,11 @@ postgresql-running:
       - cmd: postgresql-cluster-prepared
 
 {% if postgres.pkgs_extra %}
-postgresql-extra-pkgs-installed:
+{% for pkg in postgres.pkgs_extra %}
+postgresql-extra-pkgs-installed_{{ pkg }}:
   pkg.installed:
-    - pkgs: {{ postgres.pkgs_extra }}
+    - name: {{ pkg }}
+{% endfor %}
 {% endif %}
 
 {% if postgres.postgresconf %}
@@ -132,8 +134,17 @@ postgresql-tablespace-{{ name }}:
     - name: {{ name }}
     - directory: {{ tblspace.directory }}
     - user: {{ tblspace.get('runas', postgres.user) }}
-{% if tblspace.get('user') %}
-    - db_user: {{ tblspace.user }}
+{% if tblspace.get('db_user') %}
+    - db_user: {{ tblspace.db_user }}
+{% endif %}
+{% if tblspace.get('db_password') %}
+    - db_password: {{ tblspace.db_password }}
+{% endif %}
+{% if tblspace.get('db_host') %}
+    - db_host: {{ tblspace.db_host }}
+{% endif %}
+{% if tblspace.get('db_port') %}
+    - db_port: {{ tblspace.db_port }}
 {% endif %}
 {% if tblspace.get('owner') %}
     - owner: {{ tblspace.owner }}
@@ -172,8 +183,17 @@ postgresql-db-{{ name }}:
     - owner: {{ db.owner }}
     {% endif %}
     - user: {{ db.get('runas', postgres.user) }}
-    {% if db.get('user') %}
-    - db_user: {{ db.user }}
+    {% if db.get('db_user') %}
+    - db_user: {{ db.db_user }}
+    {% endif %}
+    {% if db.get('db_password') %}
+    - db_password: {{ db.db_password }}
+    {% endif %}
+    {% if db.get('db_host') %}
+    - db_host: {{ db.db_host }}
+    {% endif %}
+    {% if db.get('db_port') %}
+    - db_port: {{ db.db_port }}
     {% endif %}
     - require:
       - service: postgresql-running
@@ -184,7 +204,7 @@ postgresql-db-{{ name }}:
       - postgres_user: postgresql-user-{{ db.owner }}
     {% endif %}
     {% if db.get('tablespace') %}
-      - postgres_tablespace: postgresql-tablespace-{{ name }}
+      - postgres_tablespace: postgresql-tablespace-{{ db.get('tablespace') }}
     {% endif %}
 
 {# NOTE: postgres_schema doesn't have a 'runas' equiv. at all #}
@@ -252,7 +272,7 @@ postgresql-ext-{{ ext_name }}-for-db-{{ name }}:
       - postgres_user: postgresql-user-{{ ext.user }}
     {% endif %}
     {% if ext.get('schema') %}
-      - postgres_schema: postgresql-schema-{{ ext.schema }}
+      - postgres_schema: postgresql-schema-{{ ext.schema }}-for-db-{{ name }}
     {% endif %}
   {% endif %}
 {% endfor %}

--- a/test/integration/default/serverspec/postgres_spec.rb
+++ b/test/integration/default/serverspec/postgres_spec.rb
@@ -1,5 +1,7 @@
 require 'serverspec'
 
+set :backend, :exec
+
 describe service('postgresql') do
   it { should be_enabled }
   it { should be_running }
@@ -16,6 +18,6 @@ describe file('/srv/my_tablespace') do
   it { should be_grouped_into 'postgres' }
 end
 
-describe command('su - postgres -c "psql -qtc \"\l+ db2\""') do
-        its(:stdout) { should match(/db2.*localUser.*UTF8.*C.UTF-8.*C.UTF-8.*my_space/) }
+describe command(%q{su - postgres -c 'psql -qtc "\l+ db2"'}) do
+        its(:stdout) { should match(/db2.*localUser.*UTF8.*en_US\.UTF-8.*en_US\.UTF-8.*my_space/) }
 end


### PR DESCRIPTION
The reworks in merge #110 broke this formulas kitchen based specs.
This MR changes a few minor things, mostly  pillar.example and other inconsistent documentations.
Also, the use of db_user for `postgres_tablespace.present` and `postgres_database.present` now fits the states options, as db_password et al can be specified as well.

Please see the specs output below.

```
-----> Running serverspec test suite
-----> Installing Serverspec..
Fetching: rspec-support-3.5.0.gem (100%)
Fetching: rspec-core-3.5.2.gem (100%)
Fetching: diff-lcs-1.2.5.gem (100%)
Fetching: rspec-expectations-3.5.0.gem (100%)
Fetching: rspec-mocks-3.5.0.gem (100%)
Fetching: rspec-3.5.0.gem (100%)
Fetching: rspec-its-1.2.0.gem (100%)
Fetching: multi_json-1.12.1.gem (100%)
Fetching: net-ssh-3.2.0.gem (100%)
Fetching: net-scp-1.2.1.gem (100%)
Fetching: net-telnet-0.1.1.gem (100%)
Fetching: sfl-2.2.gem (100%)
Fetching: specinfra-2.60.3.gem (100%)
Fetching: serverspec-2.36.0.gem (100%)
-----> serverspec installed (version 2.36.0)
       /opt/chef/embedded/bin/ruby -I/tmp/busser/suites/serverspec -I/tmp/busser/gems/gems/rspec-support-3.5.0/lib:/tmp/busser/gems/gems/rspec-core-3.5.2/lib /opt/chef/embedded/bin/rspec --pattern /tmp/busser/suites/serverspec/\*\*/\*_spec.rb --color --format documentation --default-path /tmp/busser/suites/serverspec
       
       Service "postgresql"
         should be enabled
         should be running
       
       Port "5432"
         should be listening
       
       File "/srv/my_tablespace"
         should be directory
         should be mode 700
         should be owned by "postgres"
         should be grouped into "postgres"
       
       Command "su - postgres -c 'psql -qtc "\l+ db2"'"
         stdout
           should match /db2.*localUser.*UTF8.*en_US\.UTF-8.*en_US\.UTF-8.*my_space/
       
       Finished in 0.28184 seconds (files took 0.29857 seconds to load)
       8 examples, 0 failures
       
       Finished verifying <default-ubuntu-1404> (0m10.01s).
```
