### PR TITLE
Fix SLS rendering because of `pkgs_extra` Jinja variable isn't set by default

### DIFF
--- a/postgres/init.sls
+++ b/postgres/init.sls
@@ -47,13 +47,9 @@ postgresql-running:
     - require:
       - cmd: postgresql-cluster-prepared
 
-{% if postgres.pkgs_extra %}
-{% for pkg in postgres.pkgs_extra %}
-postgresql-extra-pkgs-installed_{{ pkg }}:
+postgresql-extra-pkgs-installed:
   pkg.installed:
-    - name: {{ pkg }}
-{% endfor %}
-{% endif %}
+    - pkgs: {{ postgres.pkgs_extra | default([], True) }}
 
 {% if postgres.postgresconf %}
 postgresql-conf:


### PR DESCRIPTION
Hi @gravyboat 

Currently, rendering of `init.sls` fails if there are no Pillars set, assuming we want to use only defaults:
```
[CRITICAL] Rendering SLS 'base:postgres' failed: Jinja variable 'dict object' has no attribute 'pkgs_extra'
```

This PR converts Jinja condition with loop in a compact `postgresql-extra-pkgs-installed` state which is  more clean and able to handle missing `pkgs_extra` attribute.