### PR TITLE
Set sane defaults when `use_upstream_repo` and `version` Pillars are set

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,12 +1,19 @@
 postgres:
-  pg_hba.conf: salt://postgres/pg_hba.conf
+  # Set True to configure upstream postgresql.org repository for YUM or APT
   use_upstream_repo: False
+  # Version to install from upstream repository
+  version: '9.3'
 
+  # This is Debian/Ubuntu specific package names
   pkg: 'postgresql-9.3'
   pkg_client: 'postgresql-client-9.3'
+
+  # Addtional packages to install, this should be in a list format
   pkgs_extra:
     - postgresql-contrib
     - postgresql-plpython
+
+  pg_hba.conf: salt://postgres/pg_hba.conf
 
   users:
     localUser:
@@ -78,3 +85,4 @@ postgres:
   postgresconf: |
     listen_addresses = 'localhost,*'
 
+# vim: ft=yaml:sw=2

--- a/postgres/codenamemap.yaml
+++ b/postgres/codenamemap.yaml
@@ -1,13 +1,23 @@
 {%- macro ubuntu_block(name, version) %}
+
+{%- if salt['pillar.get']('postgres:use_upstream_repo', False) %}
+
+  {%- set version = salt['pillar.get']('postgres:version', '9.5') %}
+
+{%- endif -%}
+
 {{ name }}:
   pkg_repo: deb http://apt.postgresql.org/pub/repos/apt/ {{ name }}-pgdg main
+  pkg: postgresql-{{ version }}
+  pkg_client: postgresql-client-{{ version }}
   conf_dir: /etc/postgresql/{{ version }}/main
   prepare_cluster:
     command: pg_createcluster {{ version }} main
     test: test -f /var/lib/postgresql/{{ version }}/main/PG_VERSION && test -f /etc/postgresql/{{ version }}/main/postgresql.conf
     user: root
     env: {}
-{%- endmacro %}
+
+{%- endmacro -%}
 
 {{ ubuntu_block('wheezy', 9.1) }}
 

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -26,4 +26,3 @@ postgres:
     command: service postgresql initdb
     test: test -f /var/lib/pgsql/data/PG_VERSION
     env: {}
-

--- a/postgres/init.sls
+++ b/postgres/init.sls
@@ -1,5 +1,4 @@
-# -*- mode: yaml  -*-
-# vim: syntax=yaml:sw=2
+# -*- mode: yaml -*-
 
 {% from "postgres/map.jinja" import postgres with context %}
 
@@ -7,16 +6,6 @@
 include:
   - postgres.upstream
 {% endif %}
-
-postgresql-config-dir:
-  file.directory:
-    - name: {{ postgres.conf_dir }}
-    - user: {{ postgres.user }}
-    - group: {{ postgres.group }}
-    - makedirs: True
-    - require:
-      - pkg: postgresql-installed
-      - cmd: postgresql-cluster-prepared
 
 postgresql-installed:
   pkg.installed:
@@ -38,6 +27,16 @@ postgresql-cluster-prepared:
         {{ name }}: {{ value }}
 {% endfor %}
 
+postgresql-config-dir:
+  file.directory:
+    - name: {{ postgres.conf_dir }}
+    - user: {{ postgres.user }}
+    - group: {{ postgres.group }}
+    - makedirs: True
+    - require:
+      - pkg: postgresql-installed
+      - cmd: postgresql-cluster-prepared
+
 postgresql-running:
   service.running:
     - enable: True
@@ -49,7 +48,7 @@ postgresql-running:
 
 postgresql-extra-pkgs-installed:
   pkg.installed:
-    - pkgs: {{ postgres.pkgs_extra | default([], True) }}
+    - pkgs: {{ postgres.pkgs_extra|default([], True) }}
 
 {% if postgres.postgresconf %}
 postgresql-conf:
@@ -275,4 +274,3 @@ postgresql-ext-{{ ext_name }}-for-db-{{ name }}:
 
 {% endif %}
 {% endfor %}
-

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -1,20 +1,3 @@
-RedHat:
-  pkg: postgresql-server
-  pkg_client: postgresql
-  pkg_repo: pgdg94
-  repo_baseurl: http://yum.postgresql.org/9.4/redhat/rhel-$releasever-$basearch
-  prepare_cluster:
-    test: test -f /var/lib/pgsql/data/PG_VERSION
-    env: {}
-{% if grains['os_family'] == 'RedHat' %}
-{% if grains['osmajorrelease'] >= 7 %}
-    user: root
-    command: postgresql-setup initdb
-{% else %}
-    user: postgres
-    command: initdb -D /var/lib/pgsql/data
-{% endif %}
-{% endif %}
 Arch:
   conf_dir: /var/lib/postgres/data
   prepare_cluster:
@@ -24,14 +7,53 @@ Arch:
     env: {}
   pkg_client: postgresql
   pkg_dev: postgresql
+
 Debian:
   pkg_repo_file: /etc/apt/sources.list.d/pgdg.list
   pkg_dev: postgresql-server-dev-all
   pkg_libpq_dev: libpq-dev
+
+FreeBSD:
+  user: pgsql
+
+OpenBSD:
+  user: _postgresql
+
+RedHat:
+{%- if salt['pillar.get']('postgres:use_upstream_repo', False) %}
+
+  {%- set version = salt['pillar.get']('postgres:version', '9.5') %}
+  {%- set release = version|replace('.', '') %}
+
+  version: {{ version }}
+  pkg_repo: pgdg{{ release }}
+  pkg: postgresql{{ release }}-server
+  pkg_client: postgresql{{ release }}
+  conf_dir: /var/lib/pgsql/{{ version }}/data
+  service: postgresql-{{ version }}
+  prepare_cluster:
+    user: postgres
+    command: /usr/pgsql-{{ version }}/bin/initdb -D /var/lib/pgsql/{{ version }}/data
+    test: test -f /var/lib/pgsql/{{ version }}/data/PG_VERSION
+    env: {}
+
+{%- else %}
+
+  pkg: postgresql-server
+  pkg_client: postgresql
+  prepare_cluster:
+  {%- if grains['osmajorrelease'] >= 7 %}
+    user: root
+    command: postgresql-setup initdb
+  {%- else %}
+    user: postgres
+    command: initdb -D /var/lib/pgsql/data
+  {%- endif %}
+    test: test -f /var/lib/pgsql/data/PG_VERSION
+    env: {}
+
+{%- endif %}
+
 Suse:
   pkg: postgresql-server
   pkg_client: postgresql
-FreeBSD:
-  user: pgsql
-OpenBSD:
-  user: _postgresql

--- a/postgres/upstream.sls
+++ b/postgres/upstream.sls
@@ -1,6 +1,7 @@
-{% from "postgres/map.jinja" import postgres with context %}
+{%- from "postgres/map.jinja" import postgres with context %}
 
-{% if grains['os_family'] == 'Debian' %}
+{%- if grains['os_family'] == 'Debian' %}
+
 install-postgresql-repo:
   pkgrepo.managed:
     - humanname: PostgreSQL Official Repository
@@ -10,16 +11,16 @@ install-postgresql-repo:
     - file: {{ postgres.pkg_repo_file }}
     - require_in:
       - pkg: postgresql-installed
-{% endif %}
 
-{% if grains['os_family'] == 'RedHat' %}
+{%- elif grains['os_family'] == 'RedHat' -%}
+
 install-postgresql-repo:
   file.managed:
     - name: /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG
     - source: https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
     - source_hash: md5=78b5db170d33f80ad5a47863a7476b22
   pkgrepo.managed:
-    - name: pgdg-{{ postgres.version }}-centos
+    - name: {{ postgres.pkg_repo }}
     - order: 1
     - humanname: PostgreSQL {{ postgres.version }} $releasever - $basearch
     - baseurl: https://download.postgresql.org/pub/repos/yum/{{ postgres.version }}/redhat/rhel-$releasever-$basearch
@@ -27,4 +28,5 @@ install-postgresql-repo:
     - gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG
     - require:
       - file: install-postgresql-repo
-{% endif %}
+
+{%- endif %}


### PR DESCRIPTION
This PR allows to easy use of the formula when `use_upstream_repo` Pillar item is set.
PostgreSQL packages version `9.5` will be installed by default if `version` is not set to something else.

The main part is that it defines other items of `postgres` Pillar dict to work on Debian/Ubuntu/RHEL/CentOS/etc without a need to manually set package names, paths, custom commands and so on. Of course, any of such values could be overridden in later Pillar assignments.

Basically, it will be possible to get working PostgreSQL cluster installed from upstream repo right "out-of-the-box" by only setting such Pillar:
```yaml
postgres:
  use_upstream_repo: True
  # Optionally set version:
  #version: '9.5'
```

Pillar examples file updated accordingly with comments.