### PR TITLE
Make setting `use_upstream_repo` install PostgreSQL 9.5 by default

### DIFF
--- a/postgres/codenamemap.yaml
+++ b/postgres/codenamemap.yaml
@@ -5,7 +5,8 @@
   {% endif %}
 
 {{ name }}:
-  pkg_repo: deb http://apt.postgresql.org/pub/repos/apt/ {{ name }}-pgdg main
+  pkg_repo_humanname: PostgreSQL Official Repository
+  pkg_repo: deb http://apt.postgresql.org/pub/repos/apt/ {{ name }}-pgdg main {{ version }}
   pkg: postgresql-{{ version }}
   pkg_client: postgresql-client-{{ version }}
   conf_dir: /etc/postgresql/{{ version }}/main

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -24,8 +24,9 @@ RedHat:
   {% set version = salt['pillar.get']('postgres:version', '9.5') %}
   {% set release = version|replace('.', '') %}
 
-  version: {{ version }}
   pkg_repo: pgdg{{ release }}
+  pkg_repo_humanname: PostgreSQL {{ version }} $releasever - $basearch
+  pkg_repo_url: https://download.postgresql.org/pub/repos/yum/{{ version }}/redhat/rhel-$releasever-$basearch
   pkg: postgresql{{ release }}-server
   pkg_client: postgresql{{ release }}
   conf_dir: /var/lib/pgsql/{{ version }}/data

--- a/postgres/upstream.sls
+++ b/postgres/upstream.sls
@@ -1,11 +1,11 @@
 {%- from "postgres/map.jinja" import postgres with context %}
 
-{%- if grains['os_family'] == 'Debian' %}
+{%- if grains['os_family'] == 'Debian' -%}
 
 install-postgresql-repo:
   pkgrepo.managed:
-    - humanname: PostgreSQL Official Repository
-    - name: {{ postgres.pkg_repo }} {{ postgres.version }}
+    - humanname: {{ postgres.pkg_repo_humanname }}
+    - name: {{ postgres.pkg_repo }}
     - keyid: B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
     - keyserver: keyserver.ubuntu.com
     - file: {{ postgres.pkg_repo_file }}
@@ -21,12 +21,13 @@ install-postgresql-repo:
     - source_hash: md5=78b5db170d33f80ad5a47863a7476b22
   pkgrepo.managed:
     - name: {{ postgres.pkg_repo }}
-    - order: 1
-    - humanname: PostgreSQL {{ postgres.version }} $releasever - $basearch
-    - baseurl: https://download.postgresql.org/pub/repos/yum/{{ postgres.version }}/redhat/rhel-$releasever-$basearch
+    - humanname: {{ postgres.pkg_repo_humanname }}
+    - baseurl: {{ postgres.pkg_repo_url }}
     - gpgcheck: 1
     - gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG
     - require:
       - file: install-postgresql-repo
+    - require_in:
+      - pkg: postgresql-installed
 
 {%- endif %}


### PR DESCRIPTION
Hi @gravyboat 

This PR is a follow-up for the #116 and it makes that feature actually work for Debian/Ubuntu as well.
Previously, you was required to specify `postgres:version` Pillar item for the `upstream.sls` to be rendered without an error, but RHEL systems family were OK.

Now the behavior for both platforms becomes consistent and all version dependent arguments for `pkgrepo.managed` state are expressed as `postgres` dictionary items set in `*map.yaml` files.

