### PR TITLE
ensure template compatible with python 2

### DIFF
--- a/postgres/templates/pg_hba.conf.j2
+++ b/postgres/templates/pg_hba.conf.j2
@@ -38,5 +38,5 @@ local   all             postgres                                peer
     {%- endif %}
 
   {%- endif %}
-{{ '{:<8}{:<16}{:<16}{:<24}{}'.format(*acl) -}}
+{{ '{0:<8}{1:<16}{2:<16}{3:<24}{4}'.format(*acl) -}}
 {% endfor %}


### PR DESCRIPTION
When using this formula on CentOS 6 (python 2.6), I noticed that the template threw an error because it doesn't have positional arguments in the template.

```
----------
          ID: postgresql-pg_hba
    Function: file.managed
        Name: /var/lib/pgsql/9.3/data/pg_hba.conf
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.6/site-packages/salt/state.py", line 1733, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.6/site-packages/salt/loader.py", line 1652, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.6/site-packages/salt/states/file.py", line 1644, in managed
                  **kwargs
                File "/usr/lib/python2.6/site-packages/salt/modules/file.py", line 3953, in check_managed_changes
                  **kwargs)
                File "/usr/lib/python2.6/site-packages/salt/modules/file.py", line 3623, in get_managed
                  **kwargs)
                File "/usr/lib/python2.6/site-packages/salt/utils/templates.py", line 178, in render_tmpl
                  output = render_str(tmplstr, context, tmplpath)
                File "/usr/lib/python2.6/site-packages/salt/utils/templates.py", line 415, in render_jinja_tmpl
                  trace=tracestr)
              SaltRenderError: Jinja error: zero length field name in format
              Traceback (most recent call last):
                File "/usr/lib/python2.6/site-packages/salt/utils/templates.py", line 368, in render_jinja_tmpl
                  output = template.render(**decoded_context)
                File "/usr/lib/python2.6/site-packages/jinja2/environment.py", line 969, in render
                  return self.environment.handle_exception(exc_info, True)
                File "/usr/lib/python2.6/site-packages/jinja2/environment.py", line 742, in handle_exception
                  reraise(exc_type, exc_value, tb)
                File "<template>", line 41, in top-level template code
              ValueError: zero length field name in format
              
              ; line 41
              
              ---
              [...]
                  {%- if acl|length() == 4 %}
                    {%- do acl.append('md5') %}
                  {%- endif %}
              
                {%- endif %}
              {{ '{:<8}{:<16}{:<16}{:<24}{}'.format(*acl) -}}    <======================
              {% endfor %}
              
              Traceback (most recent call last):
                File "/usr/lib/python2.6/site-packages/salt/utils/templates.py", line 368, in render_jinja_tmpl
                  output = template.render(**decoded_context)
              [...]
              ---
     Started: 13:14:16.296179
    Duration: 128.447 ms
     Changes:   
----------
```

I have addd positional arguments into the template so that it compiles correctly.