### PR TITLE
Ensure upstream repo is configured or absent depending on `use_upstream_repo`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,8 +37,8 @@ applicable.
 The state relies on the ``postgres:use_upstream_repo`` Pillar value which could
 be set as following:
 
-* ``False`` (default): makes sure that the repository configuration is absent
-* ``True``: adds the upstream repository to install packages from
+* ``True`` (default): adds the upstream repository to install packages from
+* ``False``: makes sure that the repository configuration is absent
 
 The ``postgres:version`` Pillar controls which version of the PostgreSQL
 packages should be installed from the upstream repository. Defaults to ``9.5``.

--- a/README.rst
+++ b/README.rst
@@ -16,40 +16,54 @@ Available states
 ``postgres``
 ------------
 
-Installs the postgresql package.
-
-``postgres.python``
--------------------
-
-Installs the postgresql python module
+Installs the PostgreSQL server package and prepares the DB cluster.
 
 ``postgres.client``
 -------------------
 
-Installs the postgresql client
+Installs the PostgreSQL client binaries and libraries.
+
+``postgres.python``
+-------------------
+
+Installs the PostgreSQL adapter for Python.
+
+``postgres.upstream``
+---------------------
+
+Configures the PostgreSQL Official (upstream) repository on target system if
+applicable.
+
+The state relies on the ``postgres:use_upstream_repo`` Pillar value which could
+be set as following:
+
+* ``False`` (default): makes sure that the repository configuration is absent
+* ``True``: adds the upstream repository to install packages from
+
+The ``postgres:version`` Pillar controls which version of the PostgreSQL
+packages should be installed from the upstream repository. Defaults to ``9.5``.
 
 Testing
 =======
 
-Testing is done wit kitchen-salt
+Testing is done with the ``kitchen-salt``.
 
 ``kitchen converge``
 --------------------
 
-Runs the postgres main state
+Runs the ``postgres`` main state.
 
 ``kitchen verify``
 ------------------
 
-Runs serverspec tests on the actual instance
+Runs ``serverspec`` tests on the actual instance.
 
 ``kitchen test``
 ----------------
 
-Builds and runs test from scratch
+Builds and runs tests from scratch.
 
 ``kitchen login``
 -----------------
 
-Gives you ssh to the vagrant machine for manual testing
-
+Gives you ssh to the vagrant machine for manual testing.

--- a/postgres/codenamemap.yaml
+++ b/postgres/codenamemap.yaml
@@ -1,5 +1,8 @@
 ### Set parameters based on PostgreSQL version supplied with particular distro
 
+{% set use_upstream_repo = salt['pillar.get']('postgres:use_upstream_repo', false) %}
+{% set upstream_version = salt['pillar.get']('postgres:version', '9.5') %}
+
 {% macro debian_codename(name, version, codename=none) %}
   {#
   Generate lookup dictionary map for Debian and derivative distributions
@@ -14,12 +17,14 @@
   #}
 
   {# use upstream version if configured #}
-  {% set version = upstream_version|default(version) %}
+  {% if use_upstream_repo %}
+    {% set version = upstream_version %}
+  {% endif %}
 
 {{ codename|default(name, true) }}:
   # PostgreSQL packages are mostly downloaded from `main` repo component
-  pkg_repo: 'deb http://apt.postgresql.org/pub/repos/apt/ {{ name }}-pgdg main {{ version }}'
-  pkg_repo_humanname: PostgreSQL Official Repository
+  pkg_repo:
+    name: 'deb http://apt.postgresql.org/pub/repos/apt {{ name }}-pgdg main {{ upstream_version }}'
   pkg: postgresql-{{ version }}
   pkg_client: postgresql-client-{{ version }}
   conf_dir: /etc/postgresql/{{ version }}/main
@@ -30,11 +35,6 @@
     env: {}
 
 {% endmacro %}
-
-{% if salt['pillar.get']('postgres:use_upstream_repo', false) %}
-  {# upstream version will always override all versions given below #}
-  {% set upstream_version = salt['pillar.get']('postgres:version', '9.5') %}
-{% endif %}
 
 ## Debian GNU/Linux
 {{ debian_codename('wheezy', '9.1') }}

--- a/postgres/codenamemap.yaml
+++ b/postgres/codenamemap.yaml
@@ -1,7 +1,6 @@
 ### Set parameters based on PostgreSQL version supplied with particular distro
 
-{% set use_upstream_repo = salt['pillar.get']('postgres:use_upstream_repo', false) %}
-{% set upstream_version = salt['pillar.get']('postgres:version', '9.5') %}
+{% import_yaml "postgres/repo.yaml" as repo %}
 
 {% macro debian_codename(name, version, codename=none) %}
   {#
@@ -17,14 +16,14 @@
   #}
 
   {# use upstream version if configured #}
-  {% if use_upstream_repo %}
-    {% set version = upstream_version %}
+  {% if repo.use_upstream_repo %}
+    {% set version = repo.version %}
   {% endif %}
 
 {{ codename|default(name, true) }}:
   # PostgreSQL packages are mostly downloaded from `main` repo component
   pkg_repo:
-    name: 'deb http://apt.postgresql.org/pub/repos/apt {{ name }}-pgdg main {{ upstream_version }}'
+    name: 'deb http://apt.postgresql.org/pub/repos/apt {{ name }}-pgdg main {{ repo.version }}'
   pkg: postgresql-{{ version }}
   pkg_client: postgresql-client-{{ version }}
   conf_dir: /etc/postgresql/{{ version }}/main

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -1,10 +1,10 @@
 postgres:
   use_upstream_repo: False
   pkg: postgresql
+  pkgs_extra: []
+  pkg_client: postgresql-client
   pkg_dev: postgresql-devel
   pkg_libpq_dev: postgresql-libs
-  pkg_client: postgresql-client
-  pkgs_extra: []
   python: python-psycopg2
   user: postgres
   group: postgres

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -1,5 +1,8 @@
+# Default lookup dictionary
+
 postgres:
-  use_upstream_repo: False
+  use_upstream_repo: True
+  version: '9.5'
   pkg: postgresql
   pkgs_extra: []
   pkg_client: postgresql-client

--- a/postgres/macros.jinja
+++ b/postgres/macros.jinja
@@ -1,5 +1,15 @@
 {%- from "postgres/map.jinja" import postgres with context -%}
 
+{%- macro format_kwargs(kwarg) -%}
+
+  {%- filter indent(4) %}
+    {%- for k, v in kwarg|dictsort() %}
+- {{ k }}: {{ v }}
+    {%- endfor %}
+  {%- endfilter %}
+
+{%- endmacro %}
+
 {%- macro format_state(name, state, kwarg) %}
 
   {%- do kwarg.update({'name': name}) %}
@@ -12,9 +22,7 @@
 
 {{ state }}-{{ name }}:
   {{ state }}.{{ ensure|default('present') }}:
-  {%- for k, v in kwarg|dictsort() %}
-    - {{ k }}: {{ v }}
-  {%- endfor %}
+    {{- format_kwargs(kwarg) }}
 
 {%- endmacro %}
 

--- a/postgres/osmajorreleasemap.yaml
+++ b/postgres/osmajorreleasemap.yaml
@@ -1,33 +1,36 @@
+{% import_yaml "postgres/repo.yaml" as repo %}
+
 {% if grains['os_family'] == 'RedHat' %}
 
 ### RedHat releases
 
-  {% if salt['pillar.get']('postgres:use_upstream_repo', False) %}
-    {% set version = salt['pillar.get']('postgres:version', '9.5') %}
-    {% set data_dir = '/var/lib/pgsql/' ~ version ~ '/data' %}
+  {% if repo.use_upstream_repo %}
+
+    {% set data_dir = '/var/lib/pgsql/' ~ repo.version ~ '/data' %}
 
 # PostgreSQL from upstream repository
 
 default:
   prepare_cluster:
     user: postgres
-    command: /usr/pgsql-{{ version }}/bin/initdb -D {{ data_dir }}
+    command: /usr/pgsql-{{ repo.version }}/bin/initdb -D {{ data_dir }}
     test: test -f {{ data_dir }}/PG_VERSION
     env: {}
 '6':
   prepare_cluster:
     user: root
-    command: service postgresql-{{ version }} initdb
+    command: service postgresql-{{ repo.version }} initdb
     test: test -f {{ data_dir }}/PG_VERSION
     env: {}
 '7':
   prepare_cluster:
     user: root
-    command: /usr/pgsql-{{ version }}/bin/postgresql95-setup initdb
+    command: /usr/pgsql-{{ repo.version }}/bin/postgresql95-setup initdb
     test: test -f {{ data_dir }}/PG_VERSION
     env: {}
 
   {% else %}
+
     {% set data_dir = '/var/lib/pgsql/data' %}
 
 # PostgreSQL from OS repositories

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -1,3 +1,6 @@
+{% set version = salt['pillar.get']('postgres:version', '9.5') %}
+{% set release = version|replace('.', '') %}
+
 Arch:
   conf_dir: /var/lib/postgres/data
   prepare_cluster:
@@ -9,7 +12,11 @@ Arch:
   pkg_dev: postgresql
 
 Debian:
-  pkg_repo_file: /etc/apt/sources.list.d/pgdg.list
+  pkg_repo:
+    humanname: PostgreSQL Official Repository
+    key_url: 'https://www.postgresql.org/media/keys/ACCC4CF8.asc'
+    file: /etc/apt/sources.list.d/pgdg.list
+  pkg_repo_keyid: ACCC4CF8
   pkg_dev: postgresql-server-dev-all
   pkg_libpq_dev: libpq-dev
 
@@ -20,13 +27,15 @@ OpenBSD:
   user: _postgresql
 
 RedHat:
-{% if salt['pillar.get']('postgres:use_upstream_repo', False) %}
-  {% set version = salt['pillar.get']('postgres:version', '9.5') %}
-  {% set release = version|replace('.', '') %}
+  pkg_repo:
+    name: pgdg{{ release }}
+    humanname: PostgreSQL {{ version }} $releasever - $basearch
+    baseurl: 'https://download.postgresql.org/pub/repos/yum/{{ version }}/redhat/rhel-$releasever-$basearch'
+    gpgcheck: 1
+    gpgkey: 'https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-{{ release }}'
 
-  pkg_repo: pgdg{{ release }}
-  pkg_repo_humanname: PostgreSQL {{ version }} $releasever - $basearch
-  pkg_repo_url: https://download.postgresql.org/pub/repos/yum/{{ version }}/redhat/rhel-$releasever-$basearch
+{% if salt['pillar.get']('postgres:use_upstream_repo', false) %}
+
   pkg: postgresql{{ release }}-server
   pkg_client: postgresql{{ release }}
   conf_dir: /var/lib/pgsql/{{ version }}/data

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -1,5 +1,6 @@
-{% set version = salt['pillar.get']('postgres:version', '9.5') %}
-{% set release = version|replace('.', '') %}
+{% import_yaml "postgres/repo.yaml" as repo %}
+
+{% set release = repo.version|replace('.', '') %}
 
 Arch:
   conf_dir: /var/lib/postgres/data
@@ -29,17 +30,17 @@ OpenBSD:
 RedHat:
   pkg_repo:
     name: pgdg{{ release }}
-    humanname: PostgreSQL {{ version }} $releasever - $basearch
-    baseurl: 'https://download.postgresql.org/pub/repos/yum/{{ version }}/redhat/rhel-$releasever-$basearch'
+    humanname: PostgreSQL {{ repo.version }} $releasever - $basearch
+    baseurl: 'https://download.postgresql.org/pub/repos/yum/{{ repo.version }}/redhat/rhel-$releasever-$basearch'
     gpgcheck: 1
     gpgkey: 'https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-{{ release }}'
 
-{% if salt['pillar.get']('postgres:use_upstream_repo', false) %}
+{% if repo.use_upstream_repo %}
 
   pkg: postgresql{{ release }}-server
   pkg_client: postgresql{{ release }}
-  conf_dir: /var/lib/pgsql/{{ version }}/data
-  service: postgresql-{{ version }}
+  conf_dir: /var/lib/pgsql/{{ repo.version }}/data
+  service: postgresql-{{ repo.version }}
 
 {% else %}
 

--- a/postgres/repo.yaml
+++ b/postgres/repo.yaml
@@ -1,0 +1,11 @@
+# This file allows to get PostgreSQL version and upstream repo settings
+# early from Pillar to set correct lookup dictionaty items
+
+{% import_yaml "postgres/defaults.yaml" as defaults %}
+
+use_upstream_repo: {{ salt['pillar.get']('postgres:use_upstream_repo',
+                                         defaults.postgres.use_upstream_repo) }}
+version: {{ salt['pillar.get']('postgres:version',
+                               defaults.postgres.version) }}
+
+# vim: ft=sls


### PR DESCRIPTION
Hi @gravyboat 

The main feature of this PR is to make sure that the `postgres.upstream` state removes Postgres repository configuration and GnuPG key if the `postgres:use_upstream_repo` Pillar set to `False`.
Now such behavior is documented in README.

This PR also resolves issue #58 one more time, there were regressions in previous changes.

Additional improvements:
* Make the `postgres.upstream` state more reusable, other states could safely use `sls` requisite.
* On Debian/Ubuntu, fetch GPG key from PostgreSQL website, because keyserver port is often blocked by firewalls
* Display message about repo unavailability for systems other than RHEL and Debian based.