### PR TITLE
Support only including postgres.client

### DIFF
--- a/postgres/client.sls
+++ b/postgres/client.sls
@@ -9,6 +9,10 @@ install-postgresql-client:
   pkg.installed:
     - name: {{ postgres.pkg_client }}
     - refresh: {{ postgres.use_upstream_repo }}
+{% if postgres.use_upstream_repo %}
+    - require:
+      - pkgrepo: install-postgresql-repo
+{%- endif %}
 
 {% if postgres.pkg_libpq_dev %}
 install-postgres-libpq-dev:

--- a/postgres/init.sls
+++ b/postgres/init.sls
@@ -16,6 +16,10 @@ postgresql-installed:
   pkg.installed:
     - name: {{ postgres.pkg }}
     - refresh: {{ postgres.use_upstream_repo }}
+{% if postgres.use_upstream_repo %}
+    - require:
+      - pkgrepo: install-postgresql-repo
+{%- endif %}
 
 # make sure the data directory and contents have been initialized
 postgresql-cluster-prepared:

--- a/postgres/upstream.sls
+++ b/postgres/upstream.sls
@@ -9,8 +9,6 @@ install-postgresql-repo:
     - keyid: B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
     - keyserver: keyserver.ubuntu.com
     - file: {{ postgres.pkg_repo_file }}
-    - require_in:
-      - pkg: postgresql-installed
 
 {%- elif grains['os_family'] == 'RedHat' -%}
 
@@ -27,7 +25,5 @@ install-postgresql-repo:
     - gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG
     - require:
       - file: install-postgresql-repo
-    - require_in:
-      - pkg: postgresql-installed
 
 {%- endif %}


### PR DESCRIPTION
In the current state, we must include `postgres` to satisfy the `require_in` statement in the upstream repo states. This moves the requisites to the `postgresql-installed` state allowing nodes to only include the `postgres.client` file. 