### PR TITLE
Fix missing spaces in long pg_hba.conf lines

### DIFF
--- a/postgres/templates/pg_hba.conf.j2
+++ b/postgres/templates/pg_hba.conf.j2
@@ -38,5 +38,5 @@ local   all             postgres                                peer
     {%- endif %}
 
   {%- endif %}
-{{ '{0:<8}{1:<16}{2:<16}{3:<24}{4}'.format(*acl) -}}
+{{ '{0:<7} {1:<15} {2:<15} {3:<23} {4}'.format(*acl) -}}
 {% endfor %}


### PR DESCRIPTION
In generated pg_hba.conf, fix missing spaces between arguments if an argument is longer than the column width allotted to that argument in the line.

An example pillar excerpt:

    postgres:
        # ...
        acls:
            - ['local', 'database1', 'samehost', 'user']
            - ['local', 'database1,database2,database3', 'user', 'samehost', 'md5']

Before patch, outputs are:

    local    database1       user            samehost                md5
    local   database1,database2,database3user            samehost                md5

After patch:

    local    database1       user            samehost                md5
    local   database1,database2,database3 user            samehost                md5

Second line is less readable since the columns aren't strictly adhered to anymore, but it is correctly read by postgresql at least.