### PR TITLE
[REFACTORING] Add `postgres.manage` state to provision DB objects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,11 @@ various DB objects in the cluster.
 -------------------
 
 Installs the PostgreSQL client binaries and libraries.
-Allows to create such DB objects as: users, tablespaces, databases, schemas and
+
+``postgres.manage``
+-------------------
+
+Creates such DB objects as: users, tablespaces, databases, schemas and
 extensions. See ``pillar.example`` file for details.
 
 ``postgres.python``

--- a/postgres/client.sls
+++ b/postgres/client.sls
@@ -1,14 +1,13 @@
 {%- from "postgres/map.jinja" import postgres with context -%}
-{%- from "postgres/macros.jinja" import format_state with context -%}
 
 {%- set pkgs = [] %}
 {%- for pkg in (postgres.pkg_client, postgres.pkg_libpq_dev) %}
   {%- if pkg %}
     {%- do pkgs.append(pkg) %}
   {%- endif %}
-{%- endfor -%}
+{%- endfor %}
 
-{%- if postgres.use_upstream_repo -%}
+{%- if postgres.use_upstream_repo %}
 
 include:
   - postgres.upstream
@@ -46,78 +45,3 @@ postgresql-client-libs:
   {%- endfor %}
 
 {%- endif %}
-
-# Ensure that Salt is able to use postgres modules
-# after installing client binaries
-
-postgres-reload-modules:
-  test.nop:
-    - reload_modules: True
-
-# User states
-
-{%- for name, user in postgres.users|dictsort() %}
-
-{{ format_state(name, 'postgres_user', user) }}
-    - require:
-      - pkg: postgresql-client-libs
-
-{%- endfor %}
-
-# Tablespace states
-
-{%- for name, tblspace in postgres.tablespaces|dictsort() %}
-
-{{ format_state(name, 'postgres_tablespace', tblspace) }}
-    - require:
-      - pkg: postgresql-client-libs
-  {%- if 'owner' in tblspace %}
-      - postgres_user: postgres_user-{{ tblspace.owner }}
-  {%- endif %}
-
-{%- endfor %}
-
-# Database states
-
-{%- for name, db in postgres.databases|dictsort() %}
-
-{{ format_state(name, 'postgres_database', db) }}
-    - require:
-      - pkg: postgresql-client-libs
-  {%- if 'owner' in db %}
-      - postgres_user: postgres_user-{{ db.owner }}
-  {%- endif %}
-  {%- if 'tablespace' in db %}
-      - postgres_tablespace: postgres_tablespace-{{ db.tablespace }}
-  {%- endif %}
-
-{%- endfor %}
-
-# Schema states
-
-{%- for name, schema in postgres.schemas|dictsort() %}
-
-{{ format_state(name, 'postgres_schema', schema) }}
-    - require:
-      - pkg: postgresql-client-libs
-  {%- if 'owner' in schema %}
-      - postgres_user: postgres_user-{{ schema.owner }}
-  {%- endif %}
-
-{%- endfor %}
-
-# Extension states
-
-{%- for name, extension in postgres.extensions|dictsort() %}
-
-{{ format_state(name, 'postgres_extension', extension) }}
-    - require:
-      - pkg: postgresql-client-libs
-  {%- if 'maintenance_db' in extension %}
-      - postgres_database: postgres_database-{{ extension.maintenance_db }}
-  {%- endif %}
-  {%- if 'schema' in extension %}
-      - postgres_schema: postgres_schema-{{ extension.schema }}
-  {%- endif %}
-
-{%- endfor %}

--- a/postgres/init.sls
+++ b/postgres/init.sls
@@ -1,3 +1,4 @@
 include:
   - postgres.server
   - postgres.client
+  - postgres.manage

--- a/postgres/manage.sls
+++ b/postgres/manage.sls
@@ -1,0 +1,86 @@
+{%- from "postgres/map.jinja" import postgres with context -%}
+{%- from "postgres/macros.jinja" import format_state with context -%}
+
+{%- if not salt.get('postgres.user_create') %}
+
+# Salt states for managing PostgreSQL is not available,
+# need to provision client binaries first
+
+include:
+  - postgres.client
+
+{%- endif %}
+
+# Ensure that Salt is able to use postgres modules
+
+postgres-reload-modules:
+  test.nop:
+    - reload_modules: True
+
+# User states
+
+{%- for name, user in postgres.users|dictsort() %}
+
+{{ format_state(name, 'postgres_user', user) }}
+    - require:
+      - test: postgres-reload-modules
+
+{%- endfor %}
+
+# Tablespace states
+
+{%- for name, tblspace in postgres.tablespaces|dictsort() %}
+
+{{ format_state(name, 'postgres_tablespace', tblspace) }}
+    - require:
+      - test: postgres-reload-modules
+  {%- if 'owner' in tblspace %}
+      - postgres_user: postgres_user-{{ tblspace.owner }}
+  {%- endif %}
+
+{%- endfor %}
+
+# Database states
+
+{%- for name, db in postgres.databases|dictsort() %}
+
+{{ format_state(name, 'postgres_database', db) }}
+    - require:
+      - test: postgres-reload-modules
+  {%- if 'owner' in db %}
+      - postgres_user: postgres_user-{{ db.owner }}
+  {%- endif %}
+  {%- if 'tablespace' in db %}
+      - postgres_tablespace: postgres_tablespace-{{ db.tablespace }}
+  {%- endif %}
+
+{%- endfor %}
+
+# Schema states
+
+{%- for name, schema in postgres.schemas|dictsort() %}
+
+{{ format_state(name, 'postgres_schema', schema) }}
+    - require:
+      - test: postgres-reload-modules
+  {%- if 'owner' in schema %}
+      - postgres_user: postgres_user-{{ schema.owner }}
+  {%- endif %}
+
+{%- endfor %}
+
+# Extension states
+
+{%- for name, extension in postgres.extensions|dictsort() %}
+
+{{ format_state(name, 'postgres_extension', extension) }}
+    - require:
+      - test: postgres-reload-modules
+  {%- if 'maintenance_db' in extension %}
+      - postgres_database: postgres_database-{{ extension.maintenance_db }}
+  {%- endif %}
+  {%- if 'schema' in extension %}
+      - postgres_schema: postgres_schema-{{ extension.schema }}
+  {%- endif %}
+
+{%- endfor %}


### PR DESCRIPTION
This is a follow-up for the PR #127 which introduces `postgres.manage` state according to the discussion we have took there.

So, client binaries would be provisioned only when Salt is unable to call `postgres` exec module functions during the (high)state run. This makes "standalone" provisioning of PostgreSQL DB much faster on systems or appliances were server/client binaries are already available.