### PR TITLE
Workaround a bug in saltstack/salt#37935 for release v2016.11.0

### DIFF
--- a/postgres/manage.sls
+++ b/postgres/manage.sls
@@ -8,6 +8,10 @@
 
 include:
   - postgres.client
+  {%- if 'server_bins' in postgres and grains['saltversion'] == '2016.11.0' %}
+  # FIXME: Salt v2016.11.0 bug https://github.com/saltstack/salt/issues/37935
+  - postgres.server
+  {%- endif %}
 
 {%- endif %}
 

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -69,6 +69,15 @@ RedHat:
     - psql
     - reindexdb
     - vacuumdb
+  server_bins:
+    - initdb
+    - pg_controldata
+    - pg_ctl
+    - pg_resetxlog
+    - postgres
+    - postgresql{{ release }}-check-db-dir
+    - postgresql{{ release }}-setup
+    - postmaster
 
 {% else %}
 

--- a/postgres/server.sls
+++ b/postgres/server.sls
@@ -92,3 +92,24 @@ postgresql-tablespace-dir-{{ name }}:
       - group
 
 {%- endfor %}
+
+{%- if 'bin_dir' in postgres %}
+
+# Make server binaries available in $PATH
+
+  {%- for bin in postgres.server_bins %}
+
+    {%- set path = salt['file.join'](postgres.bin_dir, bin) %}
+
+{{ bin }}:
+  alternatives.install:
+    - link: {{ salt['file.join']('/usr/bin', bin) }}
+    - path: {{ path }}
+    - priority: 30
+    - onlyif: test -f {{ path }}
+    - require:
+      - pkg: postgresql-server
+
+  {%- endfor %}
+
+{%- endif %}


### PR DESCRIPTION
This PR adds a workaround for Salt issue https://github.com/saltstack/salt/issues/37935 which was introduced in release `2016.11.0`. It seems to be fixed now by PR saltstack/salt#37993, and the fix should be available in the future point release.

Till that moment we still have the latest stable Salt packages available at https://repo.saltstack.com which do have mentioned bug. It affects all PostgreSQL versions for RHEL systems installed from the upstream repository.

Proposed workaround is to make sure that the PostgreSQL server binaries also available in the system `$PATH`, as it was done with client executables earlier. It also may be useful for some people managing parts of the installation manually.
The `postgresql.manage` state will include a dependency for the `postgres.server` state (which installs binaries) only for particular Salt version `2016.11.0` on RHEL platforms.

Ping @gravyboat 