### PR TITLE
Fix and set useful backup extension for postgresql.conf file

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -14,9 +14,10 @@ postgres:
     - postgresql-contrib
     - postgresql-plpython
 
-  # This section will append your configuration to postgresql.conf.
+  # Append the lines under this item to your postgresql.conf file.
+  # Pay attention to indent exactly with 4 spaces for all lines.
   postgresconf: |
-    listen_addresses = 'localhost,*'
+    listen_addresses = '*'  # listen on all interfaces
 
   # Backup extension for postgresql.conf file, defaults to `.bak`.
   # Set to False to stop creation of backup on postgresql.conf changes.

--- a/pillar.example
+++ b/pillar.example
@@ -14,6 +14,16 @@ postgres:
     - postgresql-contrib
     - postgresql-plpython
 
+  # This section will append your configuration to postgresql.conf.
+  postgresconf: |
+    listen_addresses = 'localhost,*'
+
+  # Backup extension for postgresql.conf file, defaults to `.bak`.
+  # Set to False to stop creation of backup on postgresql.conf changes.
+  {%- if 'status.time' in salt.keys() %}
+  postgresconf_backup: ".backup@{{ salt['status.time']('%y-%m-%d_%H:%M:%S') }}"
+  {%- endif %}
+
   # Path to the `pg_hba.conf` file Jinja template on Salt Fileserver
   pg_hba.conf: salt://postgres/templates/pg_hba.conf.j2
 
@@ -87,11 +97,13 @@ postgres:
     absentUser:
       ensure: absent
 
+  # tablespaces to be created
   tablespaces:
     my_space:
       directory: /srv/my_tablespace
       owner: localUser
 
+  # databases to be created
   databases:
     db1:
       owner: 'localUser'
@@ -118,11 +130,4 @@ postgres:
       maintenance_db: db1
     #postgis: {}
 
-  # Backup extension defaults to .bak if postgresconf_backup is True.
-  # Set to False to stop creation of backup on postgresql.conf changes.
-  postgresconf_backup: True
-  # This section will append your configuration to postgresql.conf.
-  postgresconf: |
-    listen_addresses = 'localhost,*'
-
-# vim: ft=yaml:sw=2
+# vim: ft=yaml ts=2 sts=2 sw=2 et

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -11,23 +11,6 @@ postgres:
   python: python-psycopg2
   user: postgres
   group: postgres
-  conf_dir: /var/lib/pgsql/data
-  pg_hba.conf: salt://postgres/templates/pg_hba.conf.j2
-  acls:
-    # "local" is for Unix domain socket connections only
-    - ['local', 'all', 'all', 'peer']
-    # IPv4 local connections:
-    - ['host', 'all', 'all', '127.0.0.1/32', 'md5']
-    # IPv6 local connections:
-    - ['host', 'all', 'all', '::1/128', 'md5']
-  service: postgresql
-  users: {}
-  tablespaces: {}
-  databases: {}
-  schemas: {}
-  extensions: {}
-  postgresconf_backup: True
-  postgresconf: ""
 
   # if prepare_cluster is over-ridden in any of:
   # - osmap.yaml
@@ -39,3 +22,24 @@ postgres:
     command: service postgresql initdb
     test: test -f /var/lib/pgsql/data/PG_VERSION
     env: {}
+
+  conf_dir: /var/lib/pgsql/data
+  postgresconf: ""
+  postgresconf_backup: '.bak'
+
+  pg_hba.conf: salt://postgres/templates/pg_hba.conf.j2
+  acls:
+    # "local" is for Unix domain socket connections only
+    - ['local', 'all', 'all', 'peer']
+    # IPv4 local connections:
+    - ['host', 'all', 'all', '127.0.0.1/32', 'md5']
+    # IPv6 local connections:
+    - ['host', 'all', 'all', '::1/128', 'md5']
+
+  service: postgresql
+
+  users: {}
+  tablespaces: {}
+  databases: {}
+  schemas: {}
+  extensions: {}


### PR DESCRIPTION
This PR provides better and more flexible configuration for making a backup of `postgresql.conf` file.

Some earlier changes caused that the name of resulting backup file appeared to be `postgresql.confTrue` when using defaults, which is not pretty at all. That's fixed.

Also there is an example of how to set useful custom backup file extension with timestamp suffix, it should come in handy when you really will need to restore something.
