### PR TITLE
Skip configuring ACLs in `pg_hba.conf` if not provided

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -41,6 +41,9 @@ postgres:
   #
   # The uppercase items must be replaced by actual values.
   # METHOD could be omitted, 'md5' will be appended by default.
+  #
+  # If ``acls`` item value is empty ('', [], null), then the contents of
+  # ``pg_hba.conf`` file will not be touched at all.
   acls:
     - ['local', 'db1', 'localUser']
     - ['host', 'db2', 'remoteUser', '192.168.33.0/24']
@@ -52,7 +55,7 @@ postgres:
 
   # If Salt is unable to detect init system running in the scope of state run,
   # probably we are trying to bake a container/VM image with PostgreSQL.
-  # Use ``bake_image`` setting to contol how PostgreSQL will be started: if set
+  # Use ``bake_image`` setting to control how PostgreSQL will be started: if set
   # to ``True`` the raw ``pg_ctl`` will be utilized instead of packaged init
   # script, job or unit run with Salt ``service`` state.
   bake_image: True
@@ -62,7 +65,7 @@ postgres:
   # Create/remove users, tablespaces, databases, schema and extensions.
   # Each of these dictionaries contains PostgreSQL entities which
   # mapped to the ``postgres_*`` Salt states with arguments. See the Salt
-  # documentaion to get all supported argument for a particular state.
+  # documentation to get all supported argument for a particular state.
   #
   # Format is the following:
   #

--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -93,13 +93,17 @@ postgresql-conf:
 postgresql-pg_hba:
   file.managed:
     - name: {{ postgres.conf_dir }}/pg_hba.conf
-    - source: {{ postgres['pg_hba.conf'] }}
-    - template: jinja
     - user: {{ postgres.user }}
     - group: {{ postgres.group }}
     - mode: 600
+{%- if postgres.acls %}
+    - source: {{ postgres['pg_hba.conf'] }}
+    - template: jinja
     - defaults:
         acls: {{ postgres.acls }}
+{%- else %}
+    - replace: False
+{%- endif %}
     - require:
       - file: postgresql-config-dir
 


### PR DESCRIPTION
Hi @javierbertoli 

This PR adds possibility to skip ACL configuration in `pg_hba.conf` (use distribution or already existing file) when the `postgres:acls` Pillar contains empty value such as string(`''`), arrary (`[]`) or `null` (equivalent of not giving any value). In any case the state will ensure that the file exists and has correct permissions.

This becomes very handy if you're fine with packaged config, or would like to convert existing PostgreSQL installation to be supported by Salt, or ACLs need to be managed manually with other tools.

Could you please review this one? Thank you!

P.S. Some typos has been fixed.