### PR TITLE
Make local backup of `pg_hba.conf` file before modification

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -19,12 +19,6 @@ postgres:
   postgresconf: |
     listen_addresses = '*'  # listen on all interfaces
 
-  # Backup extension for postgresql.conf file, defaults to ``.bak``.
-  # Set to False to stop creation of backup on postgresql.conf changes.
-  {%- if 'status.time' in salt.keys() %}
-  postgresconf_backup: ".backup@{{ salt['status.time']('%y-%m-%d_%H:%M:%S') }}"
-  {%- endif %}
-
   # Path to the `pg_hba.conf` file Jinja template on Salt Fileserver
   pg_hba.conf: salt://postgres/templates/pg_hba.conf.j2
 
@@ -47,6 +41,12 @@ postgres:
   acls:
     - ['local', 'db1', 'localUser']
     - ['host', 'db2', 'remoteUser', '192.168.33.0/24']
+
+  # Backup extension for configuration files, defaults to ``.bak``.
+  # Set ``False`` to stop creation of backups when config files change.
+  {%- if 'status.time' in salt.keys() %}
+  config_backup: ".backup@{{ salt['status.time']('%y-%m-%d_%H:%M:%S') }}"
+  {%- endif %}
 
   # PostgreSQL service name
   service: postgresql

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -20,7 +20,6 @@ postgres:
 
   conf_dir: /var/lib/pgsql/data
   postgresconf: ""
-  postgresconf_backup: '.bak'
 
   pg_hba.conf: salt://postgres/templates/pg_hba.conf.j2
   acls:
@@ -30,6 +29,8 @@ postgres:
     - ['host', 'all', 'all', '127.0.0.1/32', 'md5']
     # IPv6 local connections:
     - ['host', 'all', 'all', '::1/128', 'md5']
+
+  config_backup: '.bak'
 
   service: postgresql
 


### PR DESCRIPTION
This PR enables local backup creation of modified `pg_hba.conf` file by default.
The `config_backup` Pillar setting has been introduced to trigger backup for all modified PostgreSQL server configuration files (`postgresconf` and `pg_hba.conf`).

It's very basic and useful feature, I think. @babilen or @javierbertoli , could you please review this? Thank you.