### PR TITLE
Support for custom schemas per database and custom extensions per schema

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -135,22 +135,14 @@ postgres:
       schemas:
         public:
           owner: 'localUser'
-      # enable per-db extension
-      extensions:
-        uuid-ossp:
-          schema: 'public'
-
-  # optional schemas to enable on database
-  schemas:
-    uuid_ossp:
-      dbname: db1
-      owner: localUser
-
-  # optional extensions to install in schema
-  extensions:
-    uuid-ossp:
-      schema: uuid_ossp
-      maintenance_db: db1
-    #postgis: {}
+          # enable per-schema extension
+          extensions:
+            - uuid-ossp
+        secret_business_logic:
+          owner: 'remoteUser'
+          # enable per-schema extension
+          extensions:
+            - uuid-ossp
+            - pg_trgm
 
 # vim: ft=yaml ts=2 sts=2 sw=2 et

--- a/postgres/macros.jinja
+++ b/postgres/macros.jinja
@@ -12,7 +12,6 @@
 
 {%- macro format_state(name, state, kwarg) %}
 
-  {%- do kwarg.update({'name': name}) %}
   {%- if 'ensure' in kwarg %}
     {%- set ensure = kwarg.pop('ensure') %}
   {%- endif %}

--- a/postgres/manage.sls
+++ b/postgres/manage.sls
@@ -107,6 +107,7 @@ postgres_database-{{ db_name }}:
 postgres_extension-{{ db_name }}-{{ extension }}:
   postgres_extension.present:
     - schema: {{ schema_name }}
+    - maintenance_db: {{ db_name }}
     - name: {{ extension }}
     - require:
       - test: postgres-reload-modules


### PR DESCRIPTION
Resolves #146 and #140

Removes the top level configuration of schemas and extensions in the pillar and
moved schemas under the scope of each individual db configuration. Now it is
possible to use the same name for a schema in different databases. Extensions are
configured as a list under each schema configuration. Now it is possible to
install the same extension under multiple schemas in the same database and
different databases. I updated the pillar.example to reflect the new structure.