### PR TITLE
Add support for using the same dict key, but different 'name's

### DIFF
--- a/postgres/manage.sls
+++ b/postgres/manage.sls
@@ -25,7 +25,7 @@ postgres-reload-modules:
 
 {%- for key, user in postgres.users|dictsort() %}
 
-{{ format_state(user.name or key, 'postgres_user', user) }}
+{{ format_state(user.get('name') or key, 'postgres_user', user) }}
     - require:
       - test: postgres-reload-modules
 
@@ -35,7 +35,7 @@ postgres-reload-modules:
 
 {%- for key, tblspace in postgres.tablespaces|dictsort() %}
 
-{{ format_state(tblspace.name or key, 'postgres_tablespace', tblspace) }}
+{{ format_state(tblspace.get('name') or key, 'postgres_tablespace', tblspace) }}
     - require:
       - test: postgres-reload-modules
   {%- if 'owner' in tblspace %}
@@ -48,7 +48,7 @@ postgres-reload-modules:
 
 {%- for key, db in postgres.databases|dictsort() %}
 
-{{ format_state(db.name or key, 'postgres_database', db) }}
+{{ format_state(db.get('name') or key, 'postgres_database', db) }}
     - require:
       - test: postgres-reload-modules
   {%- if 'owner' in db %}
@@ -64,7 +64,7 @@ postgres-reload-modules:
 
 {%- for key, schema in postgres.schemas|dictsort() %}
 
-{{ format_state(schema.name or key, 'postgres_schema', schema) }}
+{{ format_state(schema.get('name') or key, 'postgres_schema', schema) }}
     - require:
       - test: postgres-reload-modules
   {%- if 'owner' in schema %}
@@ -77,7 +77,7 @@ postgres-reload-modules:
 
 {%- for key, extension in postgres.extensions|dictsort() %}
 
-{{ format_state(extension.name or key, 'postgres_extension', extension) }}
+{{ format_state(extension.get('name') or key, 'postgres_extension', extension) }}
     - require:
       - test: postgres-reload-modules
   {%- if 'maintenance_db' in extension %}

--- a/postgres/manage.sls
+++ b/postgres/manage.sls
@@ -23,9 +23,9 @@ postgres-reload-modules:
 
 # User states
 
-{%- for name, user in postgres.users|dictsort() %}
+{%- for key, user in postgres.users|dictsort() %}
 
-{{ format_state(name, 'postgres_user', user) }}
+{{ format_state(user.name or key, 'postgres_user', user) }}
     - require:
       - test: postgres-reload-modules
 
@@ -33,9 +33,9 @@ postgres-reload-modules:
 
 # Tablespace states
 
-{%- for name, tblspace in postgres.tablespaces|dictsort() %}
+{%- for key, tblspace in postgres.tablespaces|dictsort() %}
 
-{{ format_state(name, 'postgres_tablespace', tblspace) }}
+{{ format_state(tblspace.name or key, 'postgres_tablespace', tblspace) }}
     - require:
       - test: postgres-reload-modules
   {%- if 'owner' in tblspace %}
@@ -46,9 +46,9 @@ postgres-reload-modules:
 
 # Database states
 
-{%- for name, db in postgres.databases|dictsort() %}
+{%- for key, db in postgres.databases|dictsort() %}
 
-{{ format_state(name, 'postgres_database', db) }}
+{{ format_state(db.name or key, 'postgres_database', db) }}
     - require:
       - test: postgres-reload-modules
   {%- if 'owner' in db %}
@@ -62,9 +62,9 @@ postgres-reload-modules:
 
 # Schema states
 
-{%- for name, schema in postgres.schemas|dictsort() %}
+{%- for key, schema in postgres.schemas|dictsort() %}
 
-{{ format_state(name, 'postgres_schema', schema) }}
+{{ format_state(schema.name or key, 'postgres_schema', schema) }}
     - require:
       - test: postgres-reload-modules
   {%- if 'owner' in schema %}
@@ -75,9 +75,9 @@ postgres-reload-modules:
 
 # Extension states
 
-{%- for name, extension in postgres.extensions|dictsort() %}
+{%- for key, extension in postgres.extensions|dictsort() %}
 
-{{ format_state(name, 'postgres_extension', extension) }}
+{{ format_state(extension.name or key, 'postgres_extension', extension) }}
     - require:
       - test: postgres-reload-modules
   {%- if 'maintenance_db' in extension %}


### PR DESCRIPTION
Hi,

I have a use case where in some other jinja templates I reference these pillar data. So I need to have a steady key and the `name` should be different for each environment.

Do you think this PR makes sense?

e.g. postgres pillar for dev env:

```
  users:
    devices_user:
      name: dev_devices_user
      ensure: present
      password: 'password'

  databases:
    devices:
      name: dev_devices
      owner: 'dev_devices_user'
      template: 'template0'
```

e.g. postgres pillar for test env:

```
  users:
    devices_user:
      name: test_devices_user
      ensure: present
      password: 'password'

  databases:
    devices:
      name: test_devices
      owner: 'test_devices_user'
      template: 'template0'
```
e.g. a Jinja template that configures my Django databases for different envs:

```
DATABASES:
  default:
    ENGINE: 'django.db.backends.postgresql'
    NAME: '{{ salt.pillar.get('postgres:databases:devices:name') }}'
    USER: '{{ salt.pillar.get('postgres:users:devices_user:name') }}'
    PASSWORD: '{{ salt.pillar.get('postgres:users:devices_user:password') }}'
```
