### PR TITLE
Improve the osmapping defaults in osmap.yaml

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -5,7 +5,7 @@ postgres:
   version: '9.3'
 
   # Package names are defined in codenamemap.yaml and osmap.yaml
-  # Extra package: ditto
+  # Extra packages: ditto
   pkgs_extra: []
 
   # Append the lines under this item to your postgresql.conf file.

--- a/pillar.example
+++ b/pillar.example
@@ -4,15 +4,12 @@ postgres:
   # Version to install from upstream repository
   version: '9.3'
 
-  # These are Debian/Ubuntu specific package names
-  pkg: 'postgresql-9.3'
-  pkg_client: 'postgresql-client-9.3'
-
-  # Additional packages to install with PostgreSQL server,
-  # this should be in a list format
-  pkgs_extra:
-    - postgresql-contrib
-    - postgresql-plpython
+  ### Package names are normally defined in osmap.yaml
+  ## pkg: 'postgresql-9.3'
+  ## pkg_client: 'postgresql-client-9.3'
+  ## pkgs_extra:
+    ## - postgresql-contrib
+    ## - postgresql-plpython
 
   # Append the lines under this item to your postgresql.conf file.
   # Pay attention to indent exactly with 4 spaces for all lines.

--- a/pillar.example
+++ b/pillar.example
@@ -7,9 +7,7 @@ postgres:
   # Package names are normally defined in osmap.yaml
   # pkg: 'postgresql-9.3'
   # pkg_client: 'postgresql-client-9.3'
-  # pkgs_extra:
-  # - postgresql-contrib
-  # - postgresql-plpython
+  pkgs_extra: []
 
   # Append the lines under this item to your postgresql.conf file.
   # Pay attention to indent exactly with 4 spaces for all lines.

--- a/pillar.example
+++ b/pillar.example
@@ -4,9 +4,10 @@ postgres:
   # Version to install from upstream repository
   version: '9.3'
 
-  # Package names are normally defined in osmap.yaml
+  # Package names are usually defined in osmap.yaml
   # pkg: 'postgresql-9.3'
   # pkg_client: 'postgresql-client-9.3'
+  # Extra package names are usually defined in osmap.yaml
   pkgs_extra: []
 
   # Append the lines under this item to your postgresql.conf file.

--- a/pillar.example
+++ b/pillar.example
@@ -4,12 +4,12 @@ postgres:
   # Version to install from upstream repository
   version: '9.3'
 
-  ### Package names are normally defined in osmap.yaml
-  ## pkg: 'postgresql-9.3'
-  ## pkg_client: 'postgresql-client-9.3'
-  ## pkgs_extra:
-    ## - postgresql-contrib
-    ## - postgresql-plpython
+  # Package names are normally defined in osmap.yaml
+  # pkg: 'postgresql-9.3'
+  # pkg_client: 'postgresql-client-9.3'
+  # pkgs_extra:
+  # - postgresql-contrib
+  # - postgresql-plpython
 
   # Append the lines under this item to your postgresql.conf file.
   # Pay attention to indent exactly with 4 spaces for all lines.
@@ -43,8 +43,6 @@ postgres:
   # Set ``False`` to stop creation of backups when config files change.
   {%- if salt['status.time']|default(none) is callable %}
   config_backup: ".backup@{{ salt['status.time']('%y-%m-%d_%H:%M:%S') }}"
-  {% else %}
-  config_backup: '.bak'
   {%- endif %}
 
   # PostgreSQL service name
@@ -57,7 +55,7 @@ postgres:
   # Use ``bake_image`` setting to control how PostgreSQL will be started: if set
   # to ``True`` the raw ``pg_ctl`` will be utilized instead of packaged init
   # script, job or unit run with Salt ``service`` state.
-  bake_image: False
+  # bake_image: True
 
   {%- endif %}
 

--- a/pillar.example
+++ b/pillar.example
@@ -43,6 +43,8 @@ postgres:
   # Set ``False`` to stop creation of backups when config files change.
   {%- if salt['status.time']|default(none) is callable %}
   config_backup: ".backup@{{ salt['status.time']('%y-%m-%d_%H:%M:%S') }}"
+  {% else %}
+  config_backup: '.bak'
   {%- endif %}
 
   # PostgreSQL service name
@@ -55,7 +57,7 @@ postgres:
   # Use ``bake_image`` setting to control how PostgreSQL will be started: if set
   # to ``True`` the raw ``pg_ctl`` will be utilized instead of packaged init
   # script, job or unit run with Salt ``service`` state.
-  bake_image: True
+  bake_image: False
 
   {%- endif %}
 

--- a/pillar.example
+++ b/pillar.example
@@ -4,10 +4,8 @@ postgres:
   # Version to install from upstream repository
   version: '9.3'
 
-  # Package names are usually defined in osmap.yaml
-  # pkg: 'postgresql-9.3'
-  # pkg_client: 'postgresql-client-9.3'
-  # Extra package names are usually defined in osmap.yaml
+  # Package names are defined in codenamemap.yaml and osmap.yaml
+  # Extra package: ditto
   pkgs_extra: []
 
   # Append the lines under this item to your postgresql.conf file.

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -19,6 +19,17 @@ Debian:
   pkg_dev: postgresql-server-dev-all
   pkg_libpq_dev: libpq-dev
 
+  pkg: 'postgresql-{{ repo.version }}'
+  pkg_client: 'postgresql-client-{{ repo.version }}'
+  pkgs_extra: [ postgresql-contrib, postgresql-plpython-{{ repo.version }}, libpostgresql-jdbc-java]
+  python: python-psycopg2
+  {% set data_dir = '/var/lib/postgresql/data' %}
+  conf_dir: {{ data_dir }}
+  prepare_cluster:
+    command: /usr/lib/postgresql/9.6/bin/initdb --pgdata={{ data_dir }}
+    test: test -f {{ data_dir }}/PG_VERSION
+    user: postgres
+
 FreeBSD:
   user: pgsql
 
@@ -39,12 +50,6 @@ RedHat:
 
   pkg: postgresql{{ release }}-server
   pkg_client: postgresql{{ release }}
-  conf_dir: /var/lib/pgsql/{{ repo.version }}/data
-  service: postgresql-{{ repo.version }}
-
-  prepare_cluster:
-    command: initdb --pgdata='{{ data_dir }}'
-    test: test -f '{{ data_dir }}/PG_VERSION'
 
   # Directory containing PostgreSQL client executables
   bin_dir: /usr/pgsql-{{ repo.version }}/bin
@@ -85,15 +90,30 @@ RedHat:
 
 {% else %}
 
+  {% set data_dir = '/var/lib/pgsql/data' %}
   pkg: postgresql-server
   pkg_client: postgresql
 
 {% endif %}
 
+  service: postgresql-{{ repo.version }}
+  pkgs_extra: [ postgresql-contrib, postgresql-plpython, postgresql-jdbc, postgresql-docs]
+  conf_dir: {{ data_dir }}
+  prepare_cluster:
+    command: initdb --pgdata='{{ data_dir }}'
+    test: test -f '{{ data_dir }}/PG_VERSION'
+    user: postgres
+
 Suse:
   pkg: postgresql-server
   pkg_client: postgresql
   pkg_libpq_dev: postgresql
+  pkgs_extra: [ postgresql-contrib, postgresql-plpython, postgresql-jdbc, postgresql-docs]
 
+  {% set data_dir = '/var/lib/pgsql/data' %}
+  prepare_cluster:
+    command: /usr/lib/postgresql/bin/initdb --pgdata={{ data_dir }}
+    test: test -f {{ data_dir }}/PG_VERSION
+    user: postgres
 
 # vim: ft=sls

--- a/postgres/repo.yaml
+++ b/postgres/repo.yaml
@@ -1,5 +1,5 @@
 # This file allows to get PostgreSQL version and upstream repo settings
-# early from Pillar to set correct lookup dictionaty items
+# early from Pillar to set correct lookup dictionary items
 
 {% import_yaml "postgres/defaults.yaml" as defaults %}
 


### PR DESCRIPTION
This PR is to resolve #156 by instead populating osmap.yaml with more accurate OS defaults.  The goal is to improve formula onboarding and working defaults.  Three files are updated:

repo.yaml
- fix typo

osmap.yaml
- update Debian, RedHat and SUSE mappings

pillar.example
- comment out pkg, pkg_client, pkg_extras stanza.

Verified on SUSE (no issues seen, all states passed)
Verified on Fedora (see #157, #158)
Todo: Ubuntu
