### PR TITLE
Support for Darwin

### DIFF
--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -95,5 +95,11 @@ Suse:
   pkg_client: postgresql
   pkg_libpq_dev: postgresql
 
+MacOS:
+  pkg: postgres
+  prepare_cluster:
+    user: _postgres
+    #binpath: /usr/local/bin
+
 
 # vim: ft=sls

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -98,6 +98,8 @@ Suse:
 MacOS:
   service: postgres
   pkg: postgres
+  pkg_client:
+  pkg_libpq_dev:
   conf_dir: /usr/local/var/postgres
   prepare_cluster:
     command: initdb -D /usr/local/var/postgres/

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -96,7 +96,7 @@ Suse:
   pkg_libpq_dev: postgresql
 
 MacOS:
-  service: postgres
+  service: postgresql
   pkg: postgresql
   pkg_client:
   pkg_libpq_dev:

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -96,10 +96,13 @@ Suse:
   pkg_libpq_dev: postgresql
 
 MacOS:
+  service: postgres
   pkg: postgres
+  conf_dir: /usr/local/var/postgres
   prepare_cluster:
+    command: initdb -D /usr/local/var/postgres/
+    test: test -f /usr/local/var/postgres/PG_VERSION
     user: _postgres
-    #binpath: /usr/local/bin
 
 
 # vim: ft=sls

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -97,14 +97,17 @@ Suse:
 
 MacOS:
   service: postgres
-  pkg: postgres
+  pkg: postgresql
   pkg_client:
   pkg_libpq_dev:
   conf_dir: /usr/local/var/postgres
+  user: _postgres
+  group: _postgres
   prepare_cluster:
     command: initdb -D /usr/local/var/postgres/
     test: test -f /usr/local/var/postgres/PG_VERSION
     user: _postgres
+    group: _postgres
 
 
 # vim: ft=sls


### PR DESCRIPTION
This Pull Request introduces support for Darwin in osmap.yaml.

Test Result: [darwin_postgres_result.txt](https://github.com/saltstack-formulas/postgres-formula/files/1326922/darwin_postgres_result.txt)
- Pillars: (no pillars) except 'use_upstream_repo: false'
- Versions: stable 2017.7.1 (bottled), HEAD, OSX 10.11.6 (15G1611) 
- 7 of 8 states successful.
- Resolves #163

