### PR TITLE
Fix for Arch Linux

### DIFF
--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -5,7 +5,7 @@
 Arch:
   conf_dir: /var/lib/postgres/data
   prepare_cluster:
-    command: initdb -D /var/lib/postgresql/data
+    command: initdb -D /var/lib/postgres/data
     test: test -f /var/lib/postgres/data/PG_VERSION
   pkg_client: postgresql-lib
   pkg_dev: postgresql

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -7,7 +7,7 @@ Arch:
   prepare_cluster:
     command: initdb -D /var/lib/postgresql/data
     test: test -f /var/lib/postgres/data/PG_VERSION
-  pkg_client: postgresql
+  pkg_client: postgresql-lib
   pkg_dev: postgresql
 
 Debian:

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -7,7 +7,7 @@ Arch:
   prepare_cluster:
     command: initdb -D /var/lib/postgres/data
     test: test -f /var/lib/postgres/data/PG_VERSION
-  pkg_client: postgresql-lib
+  pkg_client: postgresql-libs
   pkg_dev: postgresql
 
 Debian:


### PR DESCRIPTION
**Arch Linux Issue**: 

1. This PR corrects "postgres.Arch.prepare_cluster.command" value in osmap.yaml

2. The PR also corrects "pkg_client" value instead of relying on package dependencies.

Fixes: #166  
Test result: [Arch_testresult.txt](https://github.com/saltstack-formulas/postgres-formula/files/1327507/Arch_testresult.txt)

