### PR TITLE
Suse: Fix Suse stanza in osmap.yaml

### DIFF
--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -92,8 +92,9 @@ RedHat:
 
 Suse:
   pkg: postgresql-server
-  pkg_client: postgresql
-  pkg_libpq_dev: postgresql
+  pkg_client: postgresql-server
+  pkg_libpq_dev: libpq5
+  #pkgs_extra: [postgresql-jdbc, postgresql-jdbc-javadoc, postgresql-devel]
 
 
 # vim: ft=sls


### PR DESCRIPTION
This PR corrects two paramters in osmap.yaml for Suse.

Tested: OpenSuse Leap 42 server.