### PR TITLE
Suse: Introduce support for upstream repo

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,17 +1,18 @@
 postgres:
-  ## USE DISTRO REPO
+  # Set True to configure upstream postgresql.org repository for YUM or APT
   use_upstream_repo: False
-  service: postgresql
+  # Version to install from upstream repository
+  version: '9.3'
 
-  ## OR UPSTREAM REPO (Suse/Redhat)
-  # use_upstream_repo: True
-  # version: '9.5'
-  # service: postgresql-9.5
+  # These are Debian/Ubuntu specific package names
+  pkg: 'postgresql-9.3'
+  pkg_client: 'postgresql-client-9.3'
 
-  ## AND OVERRIDES
   # Additional packages to install with PostgreSQL server,
   # this should be in a list format
-  pkgs_extra: []
+  pkgs_extra:
+    - postgresql-contrib
+    - postgresql-plpython
 
   # Append the lines under this item to your postgresql.conf file.
   # Pay attention to indent exactly with 4 spaces for all lines.
@@ -46,6 +47,9 @@ postgres:
   {%- if salt['status.time']|default(none) is callable %}
   config_backup: ".backup@{{ salt['status.time']('%y-%m-%d_%H:%M:%S') }}"
   {%- endif %}
+
+  # PostgreSQL service name
+  service: postgresql
 
   {%- if grains['init'] == 'unknown' %}
 

--- a/pillar.example
+++ b/pillar.example
@@ -1,18 +1,17 @@
 postgres:
-  # Set True to configure upstream postgresql.org repository for YUM or APT
+  ## USE DISTRO REPO
   use_upstream_repo: False
-  # Version to install from upstream repository
-  version: '9.3'
+  service: postgresql
 
-  # These are Debian/Ubuntu specific package names
-  pkg: 'postgresql-9.3'
-  pkg_client: 'postgresql-client-9.3'
+  ## OR UPSTREAM REPO (Suse/Redhat)
+  # use_upstream_repo: True
+  # version: '9.3'
+  # service: postgresql-9.3
 
+  ## AND OVERRIDES
   # Additional packages to install with PostgreSQL server,
   # this should be in a list format
-  pkgs_extra:
-    - postgresql-contrib
-    - postgresql-plpython
+  pkgs_extra: []
 
   # Append the lines under this item to your postgresql.conf file.
   # Pay attention to indent exactly with 4 spaces for all lines.
@@ -47,9 +46,6 @@ postgres:
   {%- if salt['status.time']|default(none) is callable %}
   config_backup: ".backup@{{ salt['status.time']('%y-%m-%d_%H:%M:%S') }}"
   {%- endif %}
-
-  # PostgreSQL service name
-  service: postgresql
 
   {%- if grains['init'] == 'unknown' %}
 

--- a/pillar.example
+++ b/pillar.example
@@ -5,8 +5,8 @@ postgres:
 
   ## OR UPSTREAM REPO (Suse/Redhat)
   # use_upstream_repo: True
-  # version: '9.3'
-  # service: postgresql-9.3
+  # version: '9.5'
+  # service: postgresql-9.5
 
   ## AND OVERRIDES
   # Additional packages to install with PostgreSQL server,

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -94,23 +94,24 @@ Suse:
   pkg_repo:
     name: pgdg-sles-{{ release }}
     humanname: PostgreSQL {{ repo.version }} $releasever - $basearch
-    baseurl: 'https://download.postgresql.org/pub/repos/yum/{{ repo.version }}/suse/sles-$releasever-$basearch'
-    gpgcheck: 1
-    gpgkey: 'https://download.postgresql.org/pub/repos/yum/{{ repo.version }}/suse/sles-$releasever-$basearch/repodata/repomd.xml'
+    #Suse repos are suffixed 'suse/sles-12-$basearch' by upstream community convention.
+    baseurl: 'https://download.postgresql.org/pub/repos/yum/{{ repo.version }}/suse/sles-12-$basearch'
+    gpgkey:  'https://download.postgresql.org/pub/repos/yum/{{ repo.version }}/suse/sles-12-$basearch/repodata/repomd.xml'
+    #future: fix suse "4-Signatures public key is not available" issue and enable gpgcheck.
+    gpgcheck: 0
 
 {% if repo.use_upstream_repo %}
 
-  {% set data_dir = '/var/lib/pgsql/' ~ repo.version ~ '/data' %}
+  {% set lib_dir = '/var/lib/pgsql/' ~ repo.version ~ '/data' %}
 
   pkg: postgresql{{ release }}-server
   pkg_client: postgresql{{ release }}-server
-  conf_dir: /var/lib/pgsql/{{ repo.version }}/data
-  bin_dir: /usr/pgsql-{{ repo.version }}/bin
+  conf_dir: {{ lib_dir }}
   service: postgresql-{{ repo.version }}
 
   prepare_cluster:
-    command: initdb --pgdata='{{ data_dir }}'
-    test: test -f '{{ data_dir }}/PG_VERSION'
+    command: initdb --pgdata='{{ lib_dir }}'
+    test: test -f '{{ lib_dir }}/PG_VERSION'
 
   # Directory containing PostgreSQL client executables
   bin_dir: /usr/pgsql-{{ repo.version }}/bin

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -91,9 +91,34 @@ RedHat:
 {% endif %}
 
 Suse:
-  pkg: postgresql-server
-  pkg_client: postgresql
-  pkg_libpq_dev: postgresql
+  pkg_repo:
+    name: pgdg{{ release }}
+    humanname: PostgreSQL {{ repo.version }} $releasever - $basearch
+    baseurl: 'https://download.postgresql.org/pub/repos/yum/{{ repo.version }}/suse/sles-$releasever-$basearch'
+    gpgcheck: 1
+    gpgkey: 'https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-{{ release }}'
 
+{% if repo.use_upstream_repo %}
+
+  {% set data_dir = '/var/lib/pgsql/' ~ repo.version ~ '/data' %}
+
+  pkg: postgresql{{ release }}-server
+  pkg_client: postgresql{{ release }}-server
+  conf_dir: /var/lib/pgsql/{{ repo.version }}/data
+  bin_dir: /usr/pgsql-{{ repo.version }}/bin
+  service: postgresql-{{ repo.version }}
+
+  prepare_cluster:
+    command: initdb --pgdata='{{ data_dir }}'
+    test: test -f '{{ data_dir }}/PG_VERSION'
+
+{% else %}
+
+  pkg: postgresql-server
+  pkg_client: postgresql-server
+
+{% endif %}
+  pkg_libpq_dev: libpq5
+  #pkgs_extra: [postgresql-jdbc, postgresql-jdbc-javadoc, postgresql-devel]
 
 # vim: ft=sls

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -95,8 +95,8 @@ Suse:
     name: pgdg{{ release }}
     humanname: PostgreSQL {{ repo.version }} $releasever - $basearch
     baseurl: 'https://download.postgresql.org/pub/repos/yum/{{ repo.version }}/suse/sles-$releasever-$basearch'
-    gpgcheck: 1
-    gpgkey: 'https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-{{ release }}'
+    gpgcheck=1
+    gpgkey: 'https://download.postgresql.org/pub/repos/yum/{{ repo.version }}/suse/sles-$releasever-$basearch/repodata/repomd.xml'
 
 {% if repo.use_upstream_repo %}
 

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -92,10 +92,10 @@ RedHat:
 
 Suse:
   pkg_repo:
-    name: pgdg{{ release }}
+    name: pgdg-sles-{{ release }}
     humanname: PostgreSQL {{ repo.version }} $releasever - $basearch
     baseurl: 'https://download.postgresql.org/pub/repos/yum/{{ repo.version }}/suse/sles-$releasever-$basearch'
-    gpgcheck=1
+    gpgcheck: 1
     gpgkey: 'https://download.postgresql.org/pub/repos/yum/{{ repo.version }}/suse/sles-$releasever-$basearch/repodata/repomd.xml'
 
 {% if repo.use_upstream_repo %}

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -112,6 +112,42 @@ Suse:
     command: initdb --pgdata='{{ data_dir }}'
     test: test -f '{{ data_dir }}/PG_VERSION'
 
+  # Directory containing PostgreSQL client executables
+  bin_dir: /usr/pgsql-{{ repo.version }}/bin
+  client_bins:
+    - clusterdb
+    - createdb
+    - createlang
+    - createuser
+    - dropdb
+    - droplang
+    - dropuser
+    - pg_archivecleanup
+    - pg_basebackup
+    - pg_config
+    - pg_dump
+    - pg_dumpall
+    - pg_isready
+    - pg_receivexlog
+    - pg_restore
+    - pg_rewind
+    - pg_test_fsync
+    - pg_test_timing
+    - pg_upgrade
+    - pg_xlogdump
+    - pgbench
+    - psql
+    - reindexdb
+    - vacuumdb
+  server_bins:
+    - initdb
+    - pg_controldata
+    - pg_ctl
+    - pg_resetxlog
+    - postgres
+    - postgresql{{ release }}-check-db-dir
+    - postgresql{{ release }}-setup
+    - postmaster
 {% else %}
 
   pkg: postgresql-server

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -154,6 +154,8 @@ Suse:
   pkg: postgresql-server
   pkg_client: postgresql-server
 
+{% endif %}
+
 MacOS:
   service: postgresql
   pkg: postgresql


### PR DESCRIPTION
This PR is an enhancement to allow the [upstream repo](https://download.postgresql.org/pub/repos/yum/) to be used for SLES and OpenSUSE.

The osmap.yaml was updated introducing the feature. Design is  aligned with Redhat Stanza for convenience and continuity.  These log files demonstrate working "feature" on OpenSuse LEAP 42 as postgresql 9.5 software is retrieved from upstream-

1. [postgres95_nogpgcheck_run1.log.txt](https://github.com/saltstack-formulas/postgres-formula/files/1327882/postgres95_nogpgcheck_run1.log.txt)
2. [postgres95_nogpgcheck_run2.log.txt](https://github.com/saltstack-formulas/postgres-formula/files/1327883/postgres95_nogpgcheck_run2.log.txt)
3. [postgres95_nogpgcheck_run3.log.txt](https://github.com/saltstack-formulas/postgres-formula/files/1327884/postgres95_nogpgcheck_run3.log.txt)
 
**Limitation**
GPGCHECK is disabled (for now): See https://redmine.postgresql.org/issues/2732 

**Followup**
1. Fix gpgcheck on Suse - Raise ISSUE.


**Nice to Have**
The pillar.example was improved in the following manner-
- Required parameters are prominent.  For example the value of **service** differs depending on whether linux distribution or upstream repo is used.
- Unnecessary parameters (pkg, pkg_client, pkgs_extra) were removed to fix confusion.

Thanks