### PR TITLE
Support for upstream postgresql.org zypp repo

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,19 +1,20 @@
 postgres:
-  # Set True to configure upstream postgresql.org repository for YUM or APT
+  # UPSTREAM REPO
+  # Set True to configure upstream postgresql.org repository for YUM/APT/ZYPP
   use_upstream_repo: False
-  # Version to install from upstream repository
-  version: '9.3'
+  # Version to install from upstream repository (if upstream_repo: True)
+  version: '9.6'
 
-  # These are Debian/Ubuntu specific package names
-  pkg: 'postgresql-9.3'
-  pkg_client: 'postgresql-client-9.3'
-
-  # Additional packages to install with PostgreSQL server,
-  # this should be in a list format
+  # PACKAGE
+  # These pillars are typically never required.
+  # pkg: 'postgresql'
+  # pkg_client: 'postgresql-client'
+  # service: postgresql
   pkgs_extra:
     - postgresql-contrib
     - postgresql-plpython
 
+  # POSTGRES
   # Append the lines under this item to your postgresql.conf file.
   # Pay attention to indent exactly with 4 spaces for all lines.
   postgresconf: |
@@ -47,9 +48,6 @@ postgres:
   {%- if salt['status.time']|default(none) is callable %}
   config_backup: ".backup@{{ salt['status.time']('%y-%m-%d_%H:%M:%S') }}"
   {%- endif %}
-
-  # PostgreSQL service name
-  service: postgresql
 
   {%- if grains['init'] == 'unknown' %}
 

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -91,9 +91,43 @@ RedHat:
 {% endif %}
 
 Suse:
+  pkg_repo:
+    name: pgdg-sles-{{ release }}
+    humanname: PostgreSQL {{ repo.version }} $releasever - $basearch
+    #Using sles-12 upstream repo for opensuse
+    baseurl: 'https://download.postgresql.org/pub/repos/zypp/{{ repo.version }}/suse/sles-12-$basearch'
+    key_url: 'https://download.postgresql.org/pub/repos/zypp/{{ repo.version }}/suse/sles-12-$basearch/repodata/repomd.xml.key'
+    gpgcheck: 1
+    gpgautoimport: True
+
+{% if repo.use_upstream_repo %}
+  {# Pillars needed are 'use_upstream_repo: True' and 'version: n.n'. #}
+  {# Avoid setting package names as pillars, as may corrupt postgres. #}
+  {% set lib_dir = '/var/lib/pgsql/' ~ repo.version ~ '/data' %}
+
+  pkg: postgresql{{ release }}-server
+  pkg_client: postgresql{{ release }}
+  conf_dir: {{ lib_dir }}
+  service: postgresql-{{ repo.version }}
+
+  #This is postgresql-libs in defaults.yml but upstream is libpqxx
+  pkg_libpq_dev: libpqxx
+  pkg_dev: postgresql{{ release }}-devel
+  pkg_libs: postgresql{{ release }}-libs
+
+  prepare_cluster:
+    #Full path needed as initdb is NOT 'cross version compatible' binary
+    command: /usr/pgsql-{{ repo.version }}/bin/initdb --pgdata='{{ lib_dir }}'
+    test: test -f '{{ lib_dir }}/PG_VERSION'
+
+{% else %}
+
   pkg: postgresql-server
   pkg_client: postgresql
-  pkg_libpq_dev: postgresql
+  pkg_libpq_dev: libqpxx
+  pkg_libs: postgresql-libs
+
+{% endif %}
 
 MacOS:
   service: postgresql
@@ -108,6 +142,5 @@ MacOS:
     test: test -f /usr/local/var/postgres/PG_VERSION
     user: _postgres
     group: _postgres
-
 
 # vim: ft=sls


### PR DESCRIPTION
This PR is an enhancement to allow the [upstream repo](https://download.postgresql.org/pub/repos/zypp/) to be used for SLES and OpenSUSE. 

This rebased commit replaces PR https://github.com/saltstack-formulas/postgres-formula/pull/169

Tested successfully on version '9.6' and '10'. Failed with 9.5 due to upstream repo problem.

```
postgres:
  use_upstream_repo: True
  version: '10'
  pkgs_extra:
  - postgresql10-contrib
  - postgresql10-plpython

base:
  '*':
    - postgres
    - postgres.client
    - postgres.manage
    - postgres.python
    - postgres.server
    - postgres.server.image
    - postgres.upstream

---------
          ID: postgresql-repo
    Function: pkgrepo.managed
        Name: pgdg-sles-10
      Result: True
     Comment: Configured package repo 'pgdg-sles-10'
     Started: 14:32:38.642363
    Duration: 47.584 ms
     Changes:   
----------
          ID: postgresql-repo
    Function: cmd.run
        Name: zypper --gpg-auto-import-keys refresh --force
      Result: True
     Comment: Command "zypper --gpg-auto-import-keys refresh --force" run
     Started: 14:32:38.691449
    Duration: 8691.113 ms
     Changes:   
              ----------
              pid:
                  13510
              retcode:
                  0
              stderr:
              stdout:
                  Forcing raw metadata refresh
                  Retrieving repository 'pgdg-sles-10' metadata [...done]
                  Forcing building of repository cache
                  Building repository 'pgdg-sles-10' cache [....done]
                  Forcing raw metadata refresh
                  Retrieving repository 'openSUSE-Leap-42.3-Non-Oss' metadata [.done]
                  Forcing building of repository cache
                  Building repository 'openSUSE-Leap-42.3-Non-Oss' cache [....done]
                  Forcing raw metadata refresh
                  Retrieving repository 'openSUSE-Leap-42.3-Oss' metadata [..done]
                  Forcing building of repository cache
                  Building repository 'openSUSE-Leap-42.3-Oss' cache [....done]
                  Forcing raw metadata refresh
                  Retrieving repository 'openSUSE-Leap-42.3-Update' metadata [..done]
                  Forcing building of repository cache
                  Building repository 'openSUSE-Leap-42.3-Update' cache [....done]
                  Forcing raw metadata refresh
                  Retrieving repository 'openSUSE-Leap-42.3-Update-Non-Oss' metadata [..done]
                  Forcing building of repository cache
                  Building repository 'openSUSE-Leap-42.3-Update-Non-Oss' cache [....done]
                  Forcing raw metadata refresh
                  Retrieving repository 'Salt releases for SLE-based SUSE products (openSUSE_Leap_42.3)' metadata [..done]
                  Forcing building of repository cache
                  Building repository 'Salt releases for SLE-based SUSE products (openSUSE_Leap_42.3)' cache [....done]
                  All repositories have been refreshed.
----------
          ID: postgresql-server
    Function: pkg.installed
      Result: True
     Comment: All specified packages are already installed
     Started: 14:32:47.389718
    Duration: 314.426 ms
     Changes:   
----------
          ID: postgresql-cluster-prepared
    Function: cmd.run
        Name: initdb --pgdata='/var/lib/pgsql/10/data'
      Result: True
     Comment: unless execution succeeded
     Started: 14:32:47.711825
    Duration: 45.167 ms
     Changes:   
----------
          ID: postgresql-config-dir
    Function: file.directory
        Name: /var/lib/pgsql/10/data
      Result: True
     Comment: Directory /var/lib/pgsql/10/data is in the correct state
              Directory /var/lib/pgsql/10/data updated
     Started: 14:32:47.758883
    Duration: 0.474 ms
     Changes:   
----------
          ID: postgresql-pg_hba
    Function: file.managed
        Name: /var/lib/pgsql/10/data/pg_hba.conf
      Result: True
     Comment: File /var/lib/pgsql/10/data/pg_hba.conf is in the correct state
     Started: 14:32:47.759573
    Duration: 162.051 ms
     Changes:   
----------
          ID: postgresql-running
    Function: service.running
        Name: postgresql-10
      Result: True
     Comment: The service postgresql-10 is already running
     Started: 14:32:47.914996
    Duration: 22.87 ms
     Changes:   
----------
          ID: postgresql-client-libs
    Function: pkg.installed
      Result: True
     Comment: All specified packages are already installed
     Started: 14:32:47.945155
    Duration: 19.896 ms
     Changes:   
----------
          ID: postgres-reload-modules
    Function: test.nop
      Result: True
     Comment: Success!
     Started: 14:32:47.965238
    Duration: 0.398 ms
     Changes:   
----------
          ID: postgresql-python
    Function: pkg.installed
        Name: python-psycopg2
      Result: True
     Comment: All specified packages are already installed
     Started: 14:32:47.965724
    Duration: 22.854 ms
     Changes:   
----------
          ID: postgresql-start
    Function: test.show_notification
      Result: True
     Comment: The 'postgres:bake_image' Pillar is disabled (set to 'False').
     Started: 14:32:47.988690
    Duration: 0.228 ms
     Changes:   

Summary for local
-------------
Succeeded: 11 (changed=1)
Failed:     0
-------------
Total states run:     11
Total run time:    9.334 s
```