### PR TITLE
W/A hardcoding of debian alternatives priority

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -14,6 +14,10 @@ postgres:
     - postgresql-contrib
     - postgresql-plpython
 
+  #'Alternatives system' priority incremental. 0 disables feature.
+  linux:
+    altpriority: 30
+
   # Append the lines under this item to your postgresql.conf file.
   # Pay attention to indent exactly with 4 spaces for all lines.
   postgresconf: |

--- a/postgres/client.sls
+++ b/postgres/client.sls
@@ -8,14 +8,11 @@
 {%- endfor %}
 
 {%- if postgres.use_upstream_repo %}
-
 include:
   - postgres.upstream
-
 {%- endif %}
 
 # Install PostgreSQL client and libraries
-
 postgresql-client-libs:
   pkg.installed:
     - pkgs: {{ pkgs }}
@@ -25,23 +22,19 @@ postgresql-client-libs:
       - pkgrepo: postgresql-repo
 {%- endif %}
 
-{%- if 'bin_dir' in postgres %}
-
-# Make client binaries available in $PATH
-
-  {%- for bin in postgres.client_bins %}
-
-    {%- set path = salt['file.join'](postgres.bin_dir, bin) %}
+# Alternatives system. Make client binaries available in $PATH
+{%- if 'bin_dir' in postgres and postgres.linux.altpriority %}
+    {%- for bin in postgres.client_bins %}
+      {%- set path = salt['file.join'](postgres.bin_dir, bin) %}
 
 {{ bin }}:
   alternatives.install:
     - link: {{ salt['file.join']('/usr/bin', bin) }}
     - path: {{ path }}
-    - priority: 30
+    - priority: {{ postgres.linux.altpriority }}
     - onlyif: test -f {{ path }}
     - require:
       - pkg: postgresql-client-libs
 
-  {%- endfor %}
-
+    {%- endfor %}
 {%- endif %}

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -41,3 +41,7 @@ postgres:
   databases: {}
   schemas: {}
   extensions: {}
+
+  linux:
+    #Alternatives system are disabled by a 'altpriority=0' pillar.
+    altpriority:

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -46,7 +46,11 @@ RedHat:
     command: initdb --pgdata='{{ data_dir }}'
     test: test -f '{{ data_dir }}/PG_VERSION'
 
-  # Directory containing PostgreSQL client executables
+  # Alternatives system
+  linux:
+    altpriority: 30
+
+  # directory containing PostgreSQL client executables
   bin_dir: /usr/pgsql-{{ repo.version }}/bin
   client_bins:
     - clusterdb

--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -9,16 +9,12 @@
 {%- endif %}
 
 {%- if includes -%}
-
 include:
   {{ includes|yaml(false)|indent(2) }}
-
 {%- endif %}
 
 {%- set pkgs = [postgres.pkg] + postgres.pkgs_extra %}
-
 # Install, configure and start PostgreSQL server
-
 postgresql-server:
   pkg.installed:
     - pkgs: {{ pkgs }}
@@ -28,27 +24,23 @@ postgresql-server:
       - pkgrepo: postgresql-repo
 {%- endif %}
 
-{%- if 'bin_dir' in postgres %}
-
-# Make server binaries available in $PATH
-
-  {%- for bin in postgres.server_bins %}
-
-    {%- set path = salt['file.join'](postgres.bin_dir, bin) %}
+# Alternatives system. Make server binaries available in $PATH
+{%- if 'bin_dir' in postgres and postgres.linux.altpriority %}
+    {%- for bin in postgres.server_bins %}
+      {%- set path = salt['file.join'](postgres.bin_dir, bin) %}
 
 {{ bin }}:
   alternatives.install:
     - link: {{ salt['file.join']('/usr/bin', bin) }}
     - path: {{ path }}
-    - priority: 30
+    - priority: {{ postgres.linux.altpriority }}
     - onlyif: test -f {{ path }}
     - require:
       - pkg: postgresql-server
     - require_in:
       - cmd: postgresql-cluster-prepared
 
-  {%- endfor %}
-
+    {%- endfor %}
 {%- endif %}
 
 postgresql-cluster-prepared:
@@ -138,7 +130,6 @@ postgresql-tablespace-dir-{{ name }}:
 {%- if not postgres.bake_image %}
 
 # Start PostgreSQL server using OS init
-
 postgresql-running:
   service.running:
     - name: {{ postgres.service }}


### PR DESCRIPTION
The current hardcoding of '`postgres.alternatives.install.priority=30`', breaks formula reruns.

`-    - priority: 30`

This PR is a workaround solution, by exposing the value as a configurable pillar.

`+    - priority: {{ postgres.linux.altpriority|int }}`

**Implementation decisions**

1. To mimic existing behaviour the alternatives.priority value of '30' is retained by defaults.yaml.
2. Users can disable Debian Alternatives - new feature - by setting '0' as pillar value (that would be better formula default IMHO but lets go one step at a time).

