### PR TITLE
Support for PostgresApp on MacOS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,12 +17,12 @@ Available states
 ------------
 
 Installs and configures both PostgreSQL server and client with creation of various DB objects in
-the cluster.
+the cluster. This state applies to both Linux and MacOS.
 
 ``postgres.client``
 -------------------
 
-Installs the PostgreSQL client binaries and libraries.
+Installs the PostgreSQL client binaries and libraries on Linux.
 
 ``postgres.manage``
 -------------------
@@ -33,18 +33,18 @@ See ``pillar.example`` file for details.
 ``postgres.python``
 -------------------
 
-Installs the PostgreSQL adapter for Python.
+Installs the PostgreSQL adapter for Python on Linux.
 
 ``postgres.server``
 -------------------
 
-Installs the PostgreSQL server package, prepares the DB cluster and starts the server using
+Installs the PostgreSQL server package on Linux, prepares the DB cluster and starts the server using
 packaged init script, job or unit.
 
 ``postgres.server.image``
 -------------------------
 
-Installs the PostgreSQL server package, prepares the DB cluster and starts the server by issuing
+Installs the PostgreSQL server package on Linux, prepares the DB cluster and starts the server by issuing
 raw ``pg_ctl`` command. The ``postgres:bake_image`` Pillar toggles this behaviour. For example:
 
 .. code:: yaml
@@ -77,12 +77,14 @@ The state relies on the ``postgres:use_upstream_repo`` Pillar value which could 
 
 * ``True`` (default): adds the upstream repository to install packages from
 * ``False``: makes sure that the repository configuration is absent
+* ``postgresapp`` (MacOS) uses upstream PostgresApp package repository.
 
 The ``postgres:version`` Pillar controls which version of the PostgreSQL packages should be
-installed from the upstream repository. Defaults to ``9.5``.
+installed from the upstream Linux repository. Defaults to ``9.5``.
 
 Testing
 =======
+The postgres state was tested on MacOS (El Capitan 10.11.6)
 
 Testing is done with the ``kitchen-salt``.
 

--- a/pillar.example
+++ b/pillar.example
@@ -1,9 +1,14 @@
 postgres:
+
   # UPSTREAM REPO
   # Set True to configure upstream postgresql.org repository for YUM/APT/ZYPP
   use_upstream_repo: False
   # Version to install from upstream repository (if upstream_repo: True)
   version: '9.6'
+
+  ### MACOS
+  # Set to 'postgresapp' to install that upstream MacOS package
+  #use_upstream_repo: 'postgresapp'
 
   # PACKAGE
   # These pillars are typically never required.
@@ -14,10 +19,14 @@ postgres:
     - postgresql-contrib
     - postgresql-plpython
 
-
   #'Alternatives system' priority incremental. 0 disables feature.
   linux:
     altpriority: 30
+
+  # macos limits
+  limits:
+    soft: 64000
+    hard: 64000
 
   # POSTGRES
   # Append the lines under this item to your postgresql.conf file.

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -9,6 +9,8 @@ postgres:
   pkg_dev: postgresql-devel
   pkg_libpq_dev: postgresql-libs
   python: python-psycopg2
+  userhomes: /home
+  systemuser:
   user: postgres
   group: postgres
 
@@ -20,6 +22,21 @@ postgres:
 
   conf_dir: /var/lib/pgsql/data
   postgresconf: ""
+
+  macos:
+    archive: postgres.dmg
+    tmpdir: /tmp/postgrestmp
+    postgresapp:
+      #See: https://github.com/PostgresApp/PostgresApp/releases/
+      url: https://github.com/PostgresApp/PostgresApp/releases/download/v2.1.1/Postgres-2.1.1.dmg
+      sum: sha256=ac0656b522a58fd337931313f09509c09610c4a6078fe0b8e469e69af1e1750b
+    homebrew:
+      url:
+      sum:
+    dl:
+      opts: -s -L
+      interval: 60
+      retries: 2
 
   pg_hba.conf: salt://postgres/templates/pg_hba.conf.j2
   acls:

--- a/postgres/dev.sls
+++ b/postgres/dev.sls
@@ -1,13 +1,61 @@
 {% from "postgres/map.jinja" import postgres with context %}
 
-{% if postgres.pkg_dev %}
+{% if grains.os not in ('Windows', 'MacOS',) %}
+
+  {% if postgres.pkg_dev %}
 install-postgres-dev-package:
   pkg.installed:
     - name: {{ postgres.pkg_dev }}
-{% endif %}
+  {% endif %}
 
-{% if postgres.pkg_libpq_dev %}
+  {% if postgres.pkg_libpq_dev %}
 install-postgres-libpq-dev:
   pkg.installed:
     - name: {{ postgres.pkg_libpq_dev }}
+  {% endif %}
+
+{% endif %}
+
+
+{% if grains.os == 'MacOS' %}
+
+  # Darwin maxfiles limits
+  {% if postgres.limits.soft or postgres.limits.hard %}
+
+postgres_maxfiles_limits_conf:
+  file.managed:
+    - name: /Library/LaunchDaemons/limit.maxfiles.plist
+    - source: salt://postgres/templates/limit.maxfiles.plist
+    - context:
+      soft_limit: {{ postgres.limits.soft or postgres.limits.hard }}
+      hard_limit: {{ postgres.limits.hard or postgres.limits.soft }}
+    - group: wheel
+  {% endif %}
+
+  # MacOS Shortcut for system user
+  {% if postgres.systemuser|lower not in (None, '',) %}
+
+postgres-desktop-shortcut-clean:
+  file.absent:
+    - name: '{{ postgres.userhomes }}/{{ postgres.systemuser }}/Desktop/postgres'
+    - require_in:
+      - file: postgres-desktop-shortcut-add
+
+  {% endif %}
+
+postgres-desktop-shortcut-add:
+  file.managed:
+    - name: /tmp/mac_shortcut.sh
+    - source: salt://postgres/templates/mac_shortcut.sh
+    - mode: 755
+    - template: jinja
+    - context:
+      user: {{ postgres.systemuser }}
+      homes: {{ postgres.userhomes }}
+  cmd.run:
+    - name: /tmp/mac_shortcut.sh {{ postgres.use_upstream_repo }}
+    - runas: {{ postgres.systemuser }}
+    - require:
+      - file: postgres-desktop-shortcut-add
+
 {% endif %}

--- a/postgres/init.sls
+++ b/postgres/init.sls
@@ -1,4 +1,9 @@
+
 include:
+{% if grains.os == 'MacOS' %}
+  - postgres.macos
+{% else %}
   - postgres.server
   - postgres.client
   - postgres.manage
+{% endif %}

--- a/postgres/macos/init.sls
+++ b/postgres/macos/init.sls
@@ -1,0 +1,10 @@
+{% from "postgres/map.jinja" import postgres with context %}
+
+include:
+{% if postgres.use_upstream_repo == 'postgresapp' %}
+  - postgres.macos.postgresapp
+{% else %}
+  - postgres.server
+  - postgres.client
+{% endif %}
+  - postgres.dev

--- a/postgres/macos/postgresapp.sls
+++ b/postgres/macos/postgresapp.sls
@@ -1,0 +1,67 @@
+{% from "postgres/map.jinja" import postgres as pg with context %}
+
+# Cleanup first
+pg-remove-prev-archive:
+  file.absent:
+    - name: '{{ pg.macos.tmpdir }}/{{ pg.macos.archive }}'
+    - require_in:
+      - pg-extract-dirs
+
+pg-extract-dirs:
+  file.directory:
+    - names:
+      - '{{ pg.macos.tmpdir }}'
+    - makedirs: True
+    - clean: True
+    - require_in:
+      - pg-download-archive
+
+pg-download-archive:
+  pkg.installed:
+    - name: curl
+  cmd.run:
+    - name: curl {{ pg.macos.dl.opts }} -o '{{ pg.macos.tmpdir }}/{{ pg.macos.archive }}' {{ pg.macos.postgresapp.url }}
+      {% if grains['saltversioninfo'] >= [2017, 7, 0] %}
+    - retry:
+        attempts: {{ pg.macos.dl.retries }}
+        interval: {{ pg.macos.dl.interval }}
+      {% endif %}
+
+{%- if pg.macos.postgresapp.sum %}
+   #Check hashstring for archive downloads
+  {%- if grains['saltversioninfo'] <= [2016, 11, 6] %}
+pg-check-archive-hash:
+   module.run:
+     - name: file.check_hash
+     - path: '{{ pg.macos.tmpdir }}/{{ pg.macos.archive }}'
+     - file_hash: {{ pg.macos.postgresapp.sum }}
+     - onchanges:
+       - cmd: pg-download-archive
+     - require_in:
+       - archive: pg-package-install
+  {%- endif %}
+{%- endif %}
+
+pg-package-install:
+  macpackage.installed:
+    - name: '{{ pg.macos.tmpdir }}/{{ pg.macos.archive }}'
+    - store: True
+    - dmg: True
+    - app: True
+    - force: True
+    - allow_untrusted: True
+    - onchanges:
+      - cmd: pg-download-archive
+    - require_in:
+      - file: pg-package-install
+      - file: pg-remove-archive
+  file.append:
+    - name: {{ pg.userhomes }}/{{ pg.systemuser }}/.bash_profile
+    - text: 'export PATH=$PATH:/Applications/Postgres.app/Contents/Versions/latest/bin'
+
+pg-remove-archive:
+  file.absent:
+    - name: '{{ pg.macos.tmpdir }}'
+    - onchanges:
+      - macpackage: pg-package-install
+

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -95,5 +95,11 @@ Suse:
   pkg_client: postgresql
   pkg_libpq_dev: postgresql
 
+MacOS:
+  pkg: postgres
+  prepare_cluster:
+    user: _postgres
+    #binpath: /usr/local/bin
+
 
 # vim: ft=sls

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -98,6 +98,8 @@ Suse:
 MacOS:
   service: postgres
   pkg: postgres
+  pkg_client:
+  pkg_libpq_dev:
   conf_dir: /usr/local/var/postgres
   prepare_cluster:
     command: initdb -D /usr/local/var/postgres/

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -96,7 +96,7 @@ Suse:
   pkg_libpq_dev: postgresql
 
 MacOS:
-  service: postgres
+  service: postgresql
   pkg: postgresql
   pkg_client:
   pkg_libpq_dev:

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -134,17 +134,23 @@ Suse:
 {% endif %}
 
 MacOS:
-  service: postgresql
+   {# todo: homebrew postgresql #}
+   {% if repo.use_upstream_repo == 'homebrew' %}
+  service: homebrew.mxcl.postgresql
+   {% elif repo.use_upstream_repo == 'postgresapp' %}
+  service: com.postgresapp.Postgres2
+    {% endif %}
   pkg: postgresql
   pkg_client:
   pkg_libpq_dev:
-  conf_dir: /usr/local/var/postgres
-  user: _postgres
-  group: _postgres
+  userhomes: /Users
+  user: {{ repo.user }}
+  group: {{ repo.group }}
+  conf_dir: /Users/{{ repo.user }}/Library/AppSupport/postgres_{{ repo.use_upstream_repo }}
   prepare_cluster:
-    command: initdb -D /usr/local/var/postgres/
-    test: test -f /usr/local/var/postgres/PG_VERSION
-    user: _postgres
-    group: _postgres
+    command: initdb -D /Users/{{ repo.user }}/Library/AppSupport/postgres_{{ repo.use_upstream_repo }}
+    test: test -f /Users/{{ repo.user }}/Library/AppSupport/postgres_{{ repo.use_upstream_repo }}/PG_VERSION
+    user: {{ repo.user }}
+    group: {{ repo.group }}
 
 # vim: ft=sls

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -96,10 +96,13 @@ Suse:
   pkg_libpq_dev: postgresql
 
 MacOS:
+  service: postgres
   pkg: postgres
+  conf_dir: /usr/local/var/postgres
   prepare_cluster:
+    command: initdb -D /usr/local/var/postgres/
+    test: test -f /usr/local/var/postgres/PG_VERSION
     user: _postgres
-    #binpath: /usr/local/bin
 
 
 # vim: ft=sls

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -97,14 +97,17 @@ Suse:
 
 MacOS:
   service: postgres
-  pkg: postgres
+  pkg: postgresql
   pkg_client:
   pkg_libpq_dev:
   conf_dir: /usr/local/var/postgres
+  user: _postgres
+  group: _postgres
   prepare_cluster:
     command: initdb -D /usr/local/var/postgres/
     test: test -f /usr/local/var/postgres/PG_VERSION
     user: _postgres
+    group: _postgres
 
 
 # vim: ft=sls

--- a/postgres/repo.yaml
+++ b/postgres/repo.yaml
@@ -8,4 +8,12 @@ use_upstream_repo: {{ salt['pillar.get']('postgres:use_upstream_repo',
 version: {{ salt['pillar.get']('postgres:version',
                                defaults.postgres.version) }}
 
+#Early lookup for system user on MacOS
+{% if grains.os == 'MacOS' %}
+  {% set sysuser = salt['pillar.get']('postgres.user') or salt['cmd.run']("stat -f '%Su' /dev/console") %}
+  {% set sysgroup = salt['pillar.get']('postgres.group') or salt['cmd.run']("stat -f '%Sg' /dev/console") %}
+user: {{ sysuser }}
+group: {{ sysgroup }}
+{% endif %}
+
 # vim: ft=sls

--- a/postgres/templates/limit.maxfiles.plist
+++ b/postgres/templates/limit.maxfiles.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>  
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"  
+        "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">  
+  <dict>
+    <key>Label</key>
+    <string>limit.maxfiles</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>launchctl</string>
+      <string>limit</string>
+      <string>maxfiles</string>
+      <string>{{ soft_limit }}</string>
+      <string>{{ hard_limit }}</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>ServiceIPC</key>
+    <false/>
+  </dict>
+</plist> 

--- a/postgres/templates/mac_shortcut.sh
+++ b/postgres/templates/mac_shortcut.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+vendor=$1
+app="postgres.app"
+Source="/Applications/$app"
+Destination="{{ homes }}/{{ user }}/Desktop"
+/usr/bin/osascript -e "tell application \"Finder\" to make alias file to POSIX file \"$Source\" at POSIX file \"$Destination\""
+

--- a/postgres/upstream.sls
+++ b/postgres/upstream.sls
@@ -4,15 +4,15 @@
 {%- if 'pkg_repo' in postgres -%}
 
   {%- if postgres.use_upstream_repo -%}
+   # Add upstream repository for your distro
 
-# Add upstream repository for your distro
 postgresql-repo:
   pkgrepo.managed:
     {{- format_kwargs(postgres.pkg_repo) }}
 
   {%- else -%}
 
-# Remove the repo configuration (and GnuPG key) as requested
+   # Remove the repo configuration (and GnuPG key) as requested
 postgresql-repo:
   pkgrepo.absent:
     - name: {{ postgres.pkg_repo.name }}


### PR DESCRIPTION
This PR introduces support for the `PostgresApp` package on MacOS.  The package is first downloaded from http://postgresapp.com, sha-256 is verified, and installed natively on MacOS.

The tested baseline included #176 and #177 so hopefully **those commits are merged first.**   

```
** top_state **
base:
  '*':
    - postgres

** Pillars **
postgres:
{% if grains.os == 'MacOS' %}

  # Set to 'postgresapp' to install that upstream MacOS package
  use_upstream_repo: 'postgresapp'

{% else %}
  # Set False to use distro packaged postgresql.
  # Set True to use upstream postgresql.org repo for YUM/APT/ZYPP
  use_upstream_repo: False

  # Upstream version
  version: '9.6'

  # Additional packages to install with PostgreSQL server,
  # this should be in a list format and correctly named.
  pkgs_extra:
  - postgresql-contrib
  - postgresql-plpython

  # These are Debian/Ubuntu specific package names
  pkg: 'postgresql-9.6'
  pkg_client: 'postgresql-client-9.6'

  #Debian alternatives priority incremental. 0 disables feature.
  linux:
    altpriority: 30
{% endif %}

  limits:
    soft: 64000
    hard: 64000

... rest as per pillar.example ....


** Result on OS X El Capitan **

local:
----------
          ID: pg-remove-prev-archive
    Function: file.absent
        Name: /tmp/postgrestmp/postgres.dmg
      Result: True
     Comment: Removed file /tmp/postgrestmp/postgres.dmg
     Started: 10:26:44.473380
    Duration: 11.411 ms
     Changes:   
              ----------
              removed:
                  /tmp/postgrestmp/postgres.dmg
----------
          ID: pg-extract-dirs
    Function: file.directory
        Name: /tmp/postgrestmp
      Result: True
     Comment: Directory /tmp/postgrestmp is in the correct state
              Directory /tmp/postgrestmp updated
     Started: 10:26:44.484917
    Duration: 0.752 ms
     Changes:   
----------
          ID: pg-download-archive
    Function: pkg.installed
        Name: curl
      Result: True
     Comment: Package curl is already installed
     Started: 10:26:46.269667
    Duration: 733.215 ms
     Changes:   
----------
          ID: pg-download-archive
    Function: cmd.run
        Name: curl -s -L -o '/tmp/postgrestmp/postgres.dmg' https://github.com/PostgresApp/PostgresApp/releases/download/v2.1.1/Postgres-2.1.1.dmg
      Result: True
     Comment: Command "curl -s -L -o '/tmp/postgrestmp/postgres.dmg' https://github.com/PostgresApp/PostgresApp/releases/download/v2.1.1/Postgres-2.1.1.dmg" run
     Started: 10:26:47.005116
    Duration: 229067.193 ms
     Changes:   
              ----------
              pid:
                  5116
              retcode:
                  0
              stderr:
              stdout:
----------
          ID: pg-package-install
    Function: macpackage.installed
        Name: /tmp/postgrestmp/postgres.dmg
      Result: True
     Comment: Postgres.app installed
     Started: 10:30:36.295101
    Duration: 18240.587 ms
     Changes:   
              ----------
              installed:
                  - Postgres.app
----------
          ID: pg-package-install
    Function: file.append
        Name: /Users/messi/.bash_profile
      Result: True
     Comment: Appended 1 lines
     Started: 10:30:54.536223
    Duration: 20.205 ms
     Changes:   
              ----------
              diff:
                  --- 
                  
                  +++ 
                  
                  @@ -26,3 +26,4 @@
                  
                   #### HOSTS #####
                   alias tm='cd && ssh tm'
                   export PATH="/usr/local/sbin:$PATH"
                  +export PATH=$PATH:/Applications/Postgres.app/Contents/Versions/latest/bin
----------
          ID: pg-remove-archive
    Function: file.absent
        Name: /tmp/postgrestmp
      Result: True
     Comment: Removed directory /tmp/postgrestmp
     Started: 10:30:54.556690
    Duration: 2.163 ms
     Changes:   
              ----------
              removed:
                  /tmp/postgrestmp
----------
          ID: postgres_maxfiles_limits_conf
    Function: file.managed
        Name: /Library/LaunchDaemons/limit.maxfiles.plist
      Result: True
     Comment: File /Library/LaunchDaemons/limit.maxfiles.plist is in the correct state
     Started: 10:30:54.558930
    Duration: 13.938 ms
     Changes:   
----------
          ID: postgres-desktop-shortcut-clean
    Function: file.absent
        Name: /Users/messi/Desktop/postgres
      Result: True
     Comment: File /Users/messi/Desktop/postgres is not present
     Started: 10:30:54.572969
    Duration: 0.427 ms
     Changes:   
----------
          ID: postgres-desktop-shortcut-add
    Function: file.managed
        Name: /tmp/mac_shortcut.sh
      Result: True
     Comment: File /tmp/mac_shortcut.sh updated
     Started: 10:30:54.573711
    Duration: 7.17 ms
     Changes:   
              ----------
              diff:
                  New file
              mode:
                  0755
              user:
                  messi
----------
          ID: postgres-desktop-shortcut-add
    Function: cmd.run
        Name: /tmp/mac_shortcut.sh postgresapp
      Result: True
     Comment: Command "/tmp/mac_shortcut.sh postgresapp" run
     Started: 10:30:54.581287
    Duration: 440.299 ms
     Changes:   
              ----------
              pid:
                  5168
              retcode:
                  0
              stderr:
              stdout:
                  alias file Postgres of folder Desktop of folder messi of folder Users of startup disk

Summary for local
-------------
Succeeded: 11 (changed=7)
Failed:     0
-------------
Total states run:     11
Total run time:  248.537 s

```