### PR TITLE
Support for Homebrew Postgres on MacOS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,12 +17,12 @@ Available states
 ------------
 
 Installs and configures both PostgreSQL server and client with creation of various DB objects in
-the cluster.
+the cluster. This state applies to both Linux and MacOS.
 
 ``postgres.client``
 -------------------
 
-Installs the PostgreSQL client binaries and libraries.
+Installs the PostgreSQL client binaries and libraries on Linux.
 
 ``postgres.manage``
 -------------------
@@ -33,18 +33,18 @@ See ``pillar.example`` file for details.
 ``postgres.python``
 -------------------
 
-Installs the PostgreSQL adapter for Python.
+Installs the PostgreSQL adapter for Python on Linux.
 
 ``postgres.server``
 -------------------
 
-Installs the PostgreSQL server package, prepares the DB cluster and starts the server using
-packaged init script, job or unit.
+Installs the PostgreSQL server package on Linux, prepares the DB cluster and starts the server
+using packaged init script, job or unit.
 
 ``postgres.server.image``
 -------------------------
 
-Installs the PostgreSQL server package, prepares the DB cluster and starts the server by issuing
+Installs the PostgreSQL server package on Linux, prepares the DB cluster and starts the server by issuing
 raw ``pg_ctl`` command. The ``postgres:bake_image`` Pillar toggles this behaviour. For example:
 
 .. code:: yaml
@@ -76,15 +76,17 @@ applicable.
 The state relies on the ``postgres:use_upstream_repo`` Pillar value which could be set as following:
 
 * ``True`` (default): adds the upstream repository to install packages from
-* ``False``: makes sure that the repository configuration is absent
+* ``False`` makes sure that the repository configuration is absent
+* ``postgresapp`` (MacOS) uses upstream PostgresApp package repository.
 
 The ``postgres:version`` Pillar controls which version of the PostgreSQL packages should be
-installed from the upstream repository. Defaults to ``9.5``.
+installed from the upstream Linux repository. Defaults to ``9.5``.
 
 Testing
 =======
+The postgres state was tested on MacOS (El Capitan 10.11.6)
 
-Testing is done with the ``kitchen-salt``.
+Linux testing is done with the ``kitchen-salt``.
 
 ``kitchen converge``
 --------------------

--- a/pillar.example
+++ b/pillar.example
@@ -1,26 +1,26 @@
 postgres:
+  # REPO
 {% if grains.os == 'MacOS' %}
 
-  # Set to 'postgresapp' to install that upstream MacOS package
-  use_upstream_repo: 'postgresapp'
+  # Set to 'postgresapp' or 'homebrew' to install that package on MacOS
+  use_upstream_repo: 'homebrew'
 
 {% else %}
-  # Set False to use distro packaged postgresql.
-  # Set True to use upstream postgresql.org repo for YUM/APT/ZYPP
+  # Set True to configure upstream postgresql.org repository for YUM/APT/ZYPP
   use_upstream_repo: False
-
-  # Upstream version
+  # Version to install from upstream repository (if upstream_repo: True)
   version: '9.6'
 
-  # Additional packages to install with PostgreSQL server,
-  # this should be in a list format and correctly named.
-  pkgs_extra:
-  - postgresql-contrib
-  - postgresql-plpython
-
-  # These are Debian/Ubuntu specific package names
-  pkg: 'postgresql-9.6'
-  pkg_client: 'postgresql-client-9.6'
+  # PACKAGE
+  # These pillars are typically only required if formula defaults are
+  # known to 'not work' (please raise github issue).
+  # pkg: 'postgresql-9.6'
+  # pkg_client: 'postgresql-client-9.6'
+  #pkgs_extra:
+  #  - postgresql-contrib
+  #  - postgresql-plpython
+  # PostgreSQL service name
+  # service: postgresql
 
   #Debian alternatives priority incremental. 0 disables feature.
   linux:
@@ -31,6 +31,7 @@ postgres:
     soft: 64000
     hard: 64000
 
+  # POSTGRES
   # Append the lines under this item to your postgresql.conf file.
   # Pay attention to indent exactly with 4 spaces for all lines.
   postgresconf: |

--- a/pillar.example
+++ b/pillar.example
@@ -1,12 +1,12 @@
 postgres:
-  # Set True to configure upstream postgresql.org repository for YUM or APT
+  # Set True to configure upstream postgresql.org repository for YUM/APT/ZYPP
   use_upstream_repo: False
   # Version to install from upstream repository
-  version: '9.3'
+  version: '9.6'
 
   # These are Debian/Ubuntu specific package names
-  pkg: 'postgresql-9.3'
-  pkg_client: 'postgresql-client-9.3'
+  pkg: 'postgresql-9.6'
+  pkg_client: 'postgresql-client-9.6'
 
   # Additional packages to install with PostgreSQL server,
   # this should be in a list format

--- a/pillar.example
+++ b/pillar.example
@@ -1,22 +1,35 @@
 postgres:
-  # Set True to configure upstream postgresql.org repository for YUM/APT/ZYPP
+{% if grains.os == 'MacOS' %}
+
+  # Set to 'postgresapp' to install that upstream MacOS package
+  use_upstream_repo: 'postgresapp'
+
+{% else %}
+  # Set False to use distro packaged postgresql.
+  # Set True to use upstream postgresql.org repo for YUM/APT/ZYPP
   use_upstream_repo: False
-  # Version to install from upstream repository
+
+  # Upstream version
   version: '9.6'
+
+  # Additional packages to install with PostgreSQL server,
+  # this should be in a list format and correctly named.
+  pkgs_extra:
+  - postgresql-contrib
+  - postgresql-plpython
 
   # These are Debian/Ubuntu specific package names
   pkg: 'postgresql-9.6'
   pkg_client: 'postgresql-client-9.6'
 
-  # Additional packages to install with PostgreSQL server,
-  # this should be in a list format
-  pkgs_extra:
-    - postgresql-contrib
-    - postgresql-plpython
-
   #Debian alternatives priority incremental. 0 disables feature.
   linux:
     altpriority: 30
+{% endif %}
+
+  limits:
+    soft: 64000
+    hard: 64000
 
   # Append the lines under this item to your postgresql.conf file.
   # Pay attention to indent exactly with 4 spaces for all lines.

--- a/postgres/client.sls
+++ b/postgres/client.sls
@@ -8,10 +8,8 @@
 {%- endfor %}
 
 {%- if postgres.use_upstream_repo %}
-
 include:
   - postgres.upstream
-
 {%- endif %}
 
 # Install PostgreSQL client and libraries
@@ -23,14 +21,14 @@ postgresql-client-libs:
     - refresh: True
     - require:
       - pkgrepo: postgresql-repo
+       {% if grains.os_family == 'Suse' %}
+      - cmd: postgresql-repo
+       {% endif %}
 {%- endif %}
 
 {%- if 'bin_dir' in postgres %}
-
-# Make client binaries available in $PATH
-
+  # Make client binaries available in $PATH
   {%- for bin in postgres.client_bins %}
-
     {%- set path = salt['file.join'](postgres.bin_dir, bin) %}
 
 {{ bin }}:
@@ -43,5 +41,4 @@ postgresql-client-libs:
       - pkg: postgresql-client-libs
 
   {%- endfor %}
-
 {%- endif %}

--- a/postgres/client.sls
+++ b/postgres/client.sls
@@ -7,7 +7,7 @@
   {%- endif %}
 {%- endfor %}
 
-{%- if postgres.use_upstream_repo %}
+{%- if postgres.use_upstream_repo == 'True' %}
 include:
   - postgres.upstream
 {%- endif %}
@@ -16,7 +16,7 @@ include:
 postgresql-client-libs:
   pkg.installed:
     - pkgs: {{ pkgs }}
-{%- if postgres.use_upstream_repo %}
+{%- if postgres.use_upstream_repo == 'True' %}
     - refresh: True
     - require:
       - pkgrepo: postgresql-repo
@@ -28,7 +28,7 @@ postgresql-client-libs:
 # Debian Alternatives
 {%- if 'bin_dir' in postgres %}
   {% if postgres.linux.altpriority|int > 0 %}
-    {% if grains.os_family not in ('Arch',) %}
+    {% if grains.os_family not in ('Arch', 'MacOS',) %}
 
 # Make client binaries available in $PATH
 

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -9,6 +9,8 @@ postgres:
   pkg_dev: postgresql-devel
   pkg_libpq_dev: postgresql-libs
   python: python-psycopg2
+  userhomes: /home
+  systemuser: None
   user: postgres
   group: postgres
 
@@ -20,6 +22,21 @@ postgres:
 
   conf_dir: /var/lib/pgsql/data
   postgresconf: ""
+
+  macos:
+    archive: postgres.dmg
+    tmpdir: /tmp/postgrestmp
+    postgresapp:
+      #See: https://github.com/PostgresApp/PostgresApp/releases/
+      url: https://github.com/PostgresApp/PostgresApp/releases/download/v2.1.1/Postgres-2.1.1.dmg
+      sum: sha256=ac0656b522a58fd337931313f09509c09610c4a6078fe0b8e469e69af1e1750b
+    homebrew:
+      url:
+      sum:
+    dl:
+      opts: -s -L
+      interval: 60
+      retries: 2
 
   pg_hba.conf: salt://postgres/templates/pg_hba.conf.j2
   acls:

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -10,7 +10,6 @@ postgres:
   pkg_libpq_dev: postgresql-libs
   python: python-psycopg2
   userhomes: /home
-  systemuser: None
   user: postgres
   group: postgres
 
@@ -30,9 +29,6 @@ postgres:
       #See: https://github.com/PostgresApp/PostgresApp/releases/
       url: https://github.com/PostgresApp/PostgresApp/releases/download/v2.1.1/Postgres-2.1.1.dmg
       sum: sha256=ac0656b522a58fd337931313f09509c09610c4a6078fe0b8e469e69af1e1750b
-    homebrew:
-      url:
-      sum:
     dl:
       opts: -s -L
       interval: 60

--- a/postgres/dev.sls
+++ b/postgres/dev.sls
@@ -1,13 +1,61 @@
 {% from "postgres/map.jinja" import postgres with context %}
 
-{% if postgres.pkg_dev %}
+{% if grains.os not in ('Windows', 'MacOS',) %}
+
+  {% if postgres.pkg_dev %}
 install-postgres-dev-package:
   pkg.installed:
     - name: {{ postgres.pkg_dev }}
-{% endif %}
+  {% endif %}
 
-{% if postgres.pkg_libpq_dev %}
+  {% if postgres.pkg_libpq_dev %}
 install-postgres-libpq-dev:
   pkg.installed:
     - name: {{ postgres.pkg_libpq_dev }}
+  {% endif %}
+
+{% endif %}
+
+
+{% if grains.os == 'MacOS' %}
+
+  # Darwin maxfiles limits
+  {% if postgres.limits.soft or postgres.limits.hard %}
+
+postgres_maxfiles_limits_conf:
+  file.managed:
+    - name: /Library/LaunchDaemons/limit.maxfiles.plist
+    - source: salt://postgres/templates/limit.maxfiles.plist
+    - context:
+      soft_limit: {{ postgres.limits.soft or postgres.limits.hard }}
+      hard_limit: {{ postgres.limits.hard or postgres.limits.soft }}
+    - group: wheel
+  {% endif %}
+
+  # MacOS Shortcut for system user
+  {% if postgres.systemuser|lower not in (None, '',) %}
+
+postgres-desktop-shortcut-clean:
+  file.absent:
+    - name: '{{ postgres.userhomes }}/{{ postgres.systemuser }}/Desktop/postgres'
+    - require_in:
+      - file: postgres-desktop-shortcut-add
+
+  {% endif %}
+
+postgres-desktop-shortcut-add:
+  file.managed:
+    - name: /tmp/mac_shortcut.sh
+    - source: salt://postgres/templates/mac_shortcut.sh
+    - mode: 755
+    - template: jinja
+    - context:
+      user: {{ postgres.systemuser }}
+      homes: {{ postgres.userhomes }}
+  cmd.run:
+    - name: /tmp/mac_shortcut.sh {{ postgres.use_upstream_repo }}
+    - runas: {{ postgres.systemuser }}
+    - require:
+      - file: postgres-desktop-shortcut-add
+
 {% endif %}

--- a/postgres/dev.sls
+++ b/postgres/dev.sls
@@ -29,19 +29,16 @@ postgres_maxfiles_limits_conf:
     - context:
       soft_limit: {{ postgres.limits.soft or postgres.limits.hard }}
       hard_limit: {{ postgres.limits.hard or postgres.limits.soft }}
-    - group: wheel
+    - group: {{ postgres.group }}
   {% endif %}
 
-  # MacOS Shortcut for system user
-  {% if postgres.systemuser|lower not in (None, '',) %}
-
+  {% if postgres.use_upstream_repo == 'postgresapp' %}
+  # Shortcut for PostgresApp
 postgres-desktop-shortcut-clean:
   file.absent:
-    - name: '{{ postgres.userhomes }}/{{ postgres.systemuser }}/Desktop/postgres'
+    - name: '{{ postgres.userhomes }}/{{ postgres.user }}/Desktop/Postgres ({{ postgres.use_upstream_repo }})'
     - require_in:
       - file: postgres-desktop-shortcut-add
-
-  {% endif %}
 
 postgres-desktop-shortcut-add:
   file.managed:
@@ -50,12 +47,13 @@ postgres-desktop-shortcut-add:
     - mode: 755
     - template: jinja
     - context:
-      user: {{ postgres.systemuser }}
+      user: {{ postgres.user }}
       homes: {{ postgres.userhomes }}
   cmd.run:
-    - name: /tmp/mac_shortcut.sh {{ postgres.use_upstream_repo }}
-    - runas: {{ postgres.systemuser }}
+    - name: '/tmp/mac_shortcut.sh "Postgres ({{ postgres.use_upstream_repo }})"'
+    - runas: {{ postgres.user }}
     - require:
       - file: postgres-desktop-shortcut-add
+  {% endif %}
 
 {% endif %}

--- a/postgres/init.sls
+++ b/postgres/init.sls
@@ -1,4 +1,9 @@
+
 include:
+{% if grains.os == 'MacOS' %}
+  - postgres.macos
+{% else %}
   - postgres.server
   - postgres.client
   - postgres.manage
+{% endif %}

--- a/postgres/macos/init.sls
+++ b/postgres/macos/init.sls
@@ -1,0 +1,10 @@
+{% from "postgres/map.jinja" import postgres with context %}
+
+include:
+{% if postgres.use_upstream_repo == 'postgresapp' %}
+  - postgres.macos.postgresapp
+{% else %}
+  - postgres.server
+  - postgres.client
+{% endif %}
+  - postgres.dev

--- a/postgres/macos/init.sls
+++ b/postgres/macos/init.sls
@@ -3,7 +3,7 @@
 include:
 {% if postgres.use_upstream_repo == 'postgresapp' %}
   - postgres.macos.postgresapp
-{% else %}
+{% elif postgres.use_upstream_repo == 'homebrew' %}
   - postgres.server
   - postgres.client
 {% endif %}

--- a/postgres/macos/postgresapp.sls
+++ b/postgres/macos/postgresapp.sls
@@ -27,9 +27,7 @@ pg-download-archive:
         interval: {{ pg.macos.dl.interval }}
       {% endif %}
 
-{%- if pg.macos.postgresapp.sum %}
-   #Check hashstring for archive downloads
-  {%- if grains['saltversioninfo'] <= [2016, 11, 6] %}
+  {%- if pg.macos.postgresapp.sum %}
 pg-check-archive-hash:
    module.run:
      - name: file.check_hash
@@ -40,7 +38,6 @@ pg-check-archive-hash:
      - require_in:
        - archive: pg-package-install
   {%- endif %}
-{%- endif %}
 
 pg-package-install:
   macpackage.installed:
@@ -56,7 +53,7 @@ pg-package-install:
       - file: pg-package-install
       - file: pg-remove-archive
   file.append:
-    - name: {{ pg.userhomes }}/{{ pg.systemuser }}/.bash_profile
+    - name: {{ pg.userhomes }}/{{ pg.user }}/.bash_profile
     - text: 'export PATH=$PATH:/Applications/Postgres.app/Contents/Versions/latest/bin'
 
 pg-remove-archive:

--- a/postgres/macos/postgresapp.sls
+++ b/postgres/macos/postgresapp.sls
@@ -1,0 +1,67 @@
+{% from "postgres/map.jinja" import postgres as pg with context %}
+
+# Cleanup first
+pg-remove-prev-archive:
+  file.absent:
+    - name: '{{ pg.macos.tmpdir }}/{{ pg.macos.archive }}'
+    - require_in:
+      - pg-extract-dirs
+
+pg-extract-dirs:
+  file.directory:
+    - names:
+      - '{{ pg.macos.tmpdir }}'
+    - makedirs: True
+    - clean: True
+    - require_in:
+      - pg-download-archive
+
+pg-download-archive:
+  pkg.installed:
+    - name: curl
+  cmd.run:
+    - name: curl {{ pg.macos.dl.opts }} -o '{{ pg.macos.tmpdir }}/{{ pg.macos.archive }}' {{ pg.macos.postgresapp.url }}
+      {% if grains['saltversioninfo'] >= [2017, 7, 0] %}
+    - retry:
+        attempts: {{ pg.macos.dl.retries }}
+        interval: {{ pg.macos.dl.interval }}
+      {% endif %}
+
+{%- if pg.macos.postgresapp.sum %}
+   #Check hashstring for archive downloads
+  {%- if grains['saltversioninfo'] <= [2016, 11, 6] %}
+pg-check-archive-hash:
+   module.run:
+     - name: file.check_hash
+     - path: '{{ pg.macos.tmpdir }}/{{ pg.macos.archive }}'
+     - file_hash: {{ pg.macos.postgresapp.sum }}
+     - onchanges:
+       - cmd: pg-download-archive
+     - require_in:
+       - archive: pg-package-install
+  {%- endif %}
+{%- endif %}
+
+pg-package-install:
+  macpackage.installed:
+    - name: '{{ pg.macos.tmpdir }}/{{ pg.macos.archive }}'
+    - store: True
+    - dmg: True
+    - app: True
+    - force: True
+    - allow_untrusted: True
+    - onchanges:
+      - cmd: pg-download-archive
+    - require_in:
+      - file: pg-package-install
+      - file: pg-remove-archive
+  file.append:
+    - name: {{ pg.userhomes }}/{{ pg.systemuser }}/.bash_profile
+    - text: 'export PATH=$PATH:/Applications/Postgres.app/Contents/Versions/latest/bin'
+
+pg-remove-archive:
+  file.absent:
+    - name: '{{ pg.macos.tmpdir }}'
+    - onchanges:
+      - macpackage: pg-package-install
+

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -91,9 +91,38 @@ RedHat:
 {% endif %}
 
 Suse:
+  pkg_repo:
+    name: pgdg-sles-{{ release }}
+    humanname: PostgreSQL {{ repo.version }} $releasever - $basearch
+    #Using sles-12 upstream repo for opensuse
+    baseurl: 'https://download.postgresql.org/pub/repos/zypp/{{ repo.version }}/suse/sles-12-$basearch'
+    key_url: 'https://download.postgresql.org/pub/repos/zypp/{{ repo.version }}/suse/sles-12-$basearch/repodata/repomd.xml.key'
+    gpgcheck: 1
+
+{% if repo.use_upstream_repo %}
+
+  {% set lib_dir = '/var/lib/pgsql/' ~ repo.version ~ '/data' %}
+
+  pkg: postgresql{{ release }}-server
+  pkg_client: postgresql{{ release }}-server
+  conf_dir: {{ lib_dir }}
+   {% if release|int >= 10 %}
+  service: postgresql-{{ release }}
+   {% endif %}
+  pkg_libpq_dev: libpqxx
+  pkg_dev: postgresql{{ release }}-devel
+
+  prepare_cluster:
+    command: initdb --pgdata='{{ lib_dir }}'
+    test: test -f '{{ lib_dir }}/PG_VERSION'
+
+{% else %}
+
   pkg: postgresql-server
   pkg_client: postgresql
-  pkg_libpq_dev: postgresql
+  pkg_libpq_dev: libpq5
+
+{% endif %}
 
 MacOS:
   service: postgresql
@@ -108,6 +137,5 @@ MacOS:
     test: test -f /usr/local/var/postgres/PG_VERSION
     user: _postgres
     group: _postgres
-
 
 # vim: ft=sls

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -124,20 +124,24 @@ Suse:
 
 {% endif %}
 
+{% if grains.os == 'MacOS' %}
 MacOS:
-  service: postgresql
+    {% if repo.use_upstream_repo == 'homebrew' %}
+  service: homebrew.mxcl.postgresql
+    {% elif repo.use_upstream_repo == 'postgresapp' %}
+  service: com.postgresapp.Postgres2
+    {% endif %}
   pkg: postgresql
   pkg_client:
   pkg_libpq_dev:
-  conf_dir: /usr/local/var/postgres
   userhomes: /Users
-  systemuser: {{ salt['pillar.get']('postgres.systemuser') or salt['cmd.run']("stat -f '%Su' /dev/console")  }}
-  user: _postgres
-  group: _postgres
+  user: {{ repo.user }}
+  group: {{ repo.group }}
+  conf_dir: /Users/{{ repo.user }}/Library/AppSupport/postgres_{{ repo.use_upstream_repo }}
   prepare_cluster:
-    command: initdb -D /usr/local/var/postgres/
-    test: test -f /usr/local/var/postgres/PG_VERSION
-    user: _postgres
-    group: _postgres
+    command: initdb -D /Users/{{ repo.user }}/Library/AppSupport/postgres_{{ repo.use_upstream_repo }}
+    test: test -f /Users/{{ repo.user }}/Library/AppSupport/postgres_{{ repo.use_upstream_repo }}/PG_VERSION
+    user: {{ repo.user }}
+{% endif %}
 
 # vim: ft=sls

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -130,6 +130,8 @@ MacOS:
   pkg_client:
   pkg_libpq_dev:
   conf_dir: /usr/local/var/postgres
+  userhomes: /Users
+  systemuser: {{ salt['pillar.get']('postgres.systemuser') or salt['cmd.run']("stat -f '%Su' /dev/console")  }}
   user: _postgres
   group: _postgres
   prepare_cluster:

--- a/postgres/repo.yaml
+++ b/postgres/repo.yaml
@@ -8,4 +8,12 @@ use_upstream_repo: {{ salt['pillar.get']('postgres:use_upstream_repo',
 version: {{ salt['pillar.get']('postgres:version',
                                defaults.postgres.version) }}
 
+#Early lookup for system user on MacOS
+{% if grains.os == 'MacOS' %}
+  {% set sysuser = salt['pillar.get']('postgres.user') or salt['cmd.run']("stat -f '%Su' /dev/console") %}
+  {% set sysgroup = salt['pillar.get']('postgres.group') or salt['cmd.run']("stat -f '%Sg' /dev/console") %}
+user: {{ sysuser }}
+group: {{ sysgroup }}
+{% endif %}
+
 # vim: ft=sls

--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -4,7 +4,7 @@
 {%- if postgres.bake_image %}
   {%- do includes.append('postgres.server.image') %}
 {%- endif %}
-{%- if postgres.use_upstream_repo -%}
+{%- if postgres.use_upstream_repo|lower == 'true' -%}
   {%- do includes.append('postgres.upstream') %}
 {%- endif %}
 
@@ -18,18 +18,29 @@ include:
 postgresql-server:
   pkg.installed:
     - pkgs: {{ pkgs }}
-{%- if postgres.use_upstream_repo %}
+  {%- if postgres.use_upstream_repo|lower == 'true' %}
     - refresh: True
     - require:
       - pkgrepo: postgresql-repo
-{%- endif %}
+  {%- endif %}
+  {%- if grains.os == 'MacOS' %}
+     #Register as Launchd LaunchAgent for system users
+    - require_in:
+      - file: postgresql-server
+  file.managed:
+    - name: /Library/LaunchAgents/{{ postgres.service }}.plist
+    - source: /usr/local/opt/postgres/{{ postgres.service }}.plist
+    - group: wheel
+    - require_in:
+      - service: postgresql-running
+  {% else %}
 
 # Debian Alternatives
-{% if postgres.linux.altpriority|int > 0 %}
-  {%- if 'bin_dir' in postgres %}
-    {% if grains.os_family not in ('Arch',) %}
-      {%- for bin in postgres.server_bins %}
-        {%- set path = salt['file.join'](postgres.bin_dir, bin) %}
+    {% if postgres.linux.altpriority|int > 0 %}
+      {%- if 'bin_dir' in postgres %}
+        {% if grains.os_family not in ('Arch',) %}
+          {%- for bin in postgres.server_bins %}
+            {%- set path = salt['file.join'](postgres.bin_dir, bin) %}
 
 {{ bin }}:
   alternatives.install:
@@ -42,10 +53,12 @@ postgresql-server:
     - require_in:
       - cmd: postgresql-cluster-prepared
 
-      {%- endfor %}
-    {% endif %}
+          {%- endfor %}
+        {% endif %}
+      {%- endif %}
+    {%- endif %}
+
   {%- endif %}
-{%- endif %}
 
 postgresql-cluster-prepared:
   cmd.run:
@@ -63,6 +76,12 @@ postgresql-config-dir:
     - name: {{ postgres.conf_dir }}
     - user: {{ postgres.user }}
     - group: {{ postgres.group }}
+    - dir_mode: 775
+    - force: True
+    - file_mode: 644
+    - recurse:
+      - user
+      - group
     - makedirs: True
     - require:
       - cmd: postgresql-cluster-prepared
@@ -138,7 +157,9 @@ postgresql-running:
   service.running:
     - name: {{ postgres.service }}
     - enable: True
+   {% if grains.os not in ('MacOS',) %}
     - reload: True
+   {% endif %}
     - watch:
       - file: postgresql-pg_hba
 

--- a/postgres/templates/limit.maxfiles.plist
+++ b/postgres/templates/limit.maxfiles.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>  
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"  
+        "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">  
+  <dict>
+    <key>Label</key>
+    <string>limit.maxfiles</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>launchctl</string>
+      <string>limit</string>
+      <string>maxfiles</string>
+      <string>{{ soft_limit }}</string>
+      <string>{{ hard_limit }}</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>ServiceIPC</key>
+    <false/>
+  </dict>
+</plist> 

--- a/postgres/templates/mac_shortcut.sh
+++ b/postgres/templates/mac_shortcut.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-vendor=$1
+shortcutName='${1}'
 app="postgres.app"
 Source="/Applications/$app"
-Destination="{{ homes }}/{{ user }}/Desktop"
+Destination="{{ homes }}/{{ user }}/Desktop/${shortcutName}"
 /usr/bin/osascript -e "tell application \"Finder\" to make alias file to POSIX file \"$Source\" at POSIX file \"$Destination\""
 

--- a/postgres/templates/mac_shortcut.sh
+++ b/postgres/templates/mac_shortcut.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+vendor=$1
+app="postgres.app"
+Source="/Applications/$app"
+Destination="{{ homes }}/{{ user }}/Desktop"
+/usr/bin/osascript -e "tell application \"Finder\" to make alias file to POSIX file \"$Source\" at POSIX file \"$Destination\""
+

--- a/postgres/upstream.sls
+++ b/postgres/upstream.sls
@@ -4,15 +4,21 @@
 {%- if 'pkg_repo' in postgres -%}
 
   {%- if postgres.use_upstream_repo -%}
+   # Add upstream repository for your distro
 
-# Add upstream repository for your distro
 postgresql-repo:
   pkgrepo.managed:
     {{- format_kwargs(postgres.pkg_repo) }}
+    {% if grains.os_family == 'Suse' %}
+  cmd.run:
+    - name: zypper --gpg-auto-import-keys refresh --force
+    - require:
+      - pkgrepo: postgresql-repo
+    {% endif %}
 
   {%- else -%}
 
-# Remove the repo configuration (and GnuPG key) as requested
+   # Remove the repo configuration (and GnuPG key) as requested
 postgresql-repo:
   pkgrepo.absent:
     - name: {{ postgres.pkg_repo.name }}

--- a/postgres/upstream.sls
+++ b/postgres/upstream.sls
@@ -30,10 +30,12 @@ postgresql-repo:
 
 {%- else -%}
 
-# Notify that we don't manage this distro
+  {% if grains.os not in ('Windows', 'MacOS',) %}
+# Notify that we don't manage this Linux distro
 postgresql-repo:
   test.show_notification:
     - text: |
         PostgreSQL does not provide package repository for {{ grains['osfinger'] }}
+  {% endif %}
 
 {%- endif %}


### PR DESCRIPTION
This PR introduces support for the HomeBrew `Postgresql` package on MacOS, and some fixes/improvements for 'PostgresApp' package on MacOS.

The tested baseline included #176, #177, #178   **so hopefully those commits are merged first.**   

```
** top_state **

base:
  '*':
    - postgres

** Pillars **

postgres:
{% if grains.os == 'MacOS' %}

  # Set to 'postgresapp' (default) or 'homebrew' for MacOS package
  use_upstream_repo: 'homebrew'

{% else %}
  # Set False to use distro packaged postgresql.
  # Set True to use upstream postgresql.org repo for YUM/APT/ZYPP
  use_upstream_repo: False

  # Upstream version
  version: '9.6'

  # Additional packages to install with PostgreSQL server,
  # this should be in a list format and correctly named.
  pkgs_extra:
  - postgresql-contrib
  - postgresql-plpython

  # PostgreSQL service name
  service: postgresql

  # These are Debian/Ubuntu specific package names
  pkg: 'postgresql-9.6'
  pkg_client: 'postgresql-client-9.6'

  #Debian alternatives priority incremental. 0 disables feature.
  linux:
    altpriority: 30
{% endif %}

.... rest identical to pillar.example ...

** State results ***

[ERROR   ] Service homebrew.mxcl.postgresql failed to start
local:
----------
          ID: postgresql-server
    Function: pkg.installed
      Result: True
     Comment: The following packages were installed/updated: postgresql
     Started: 13:13:12.225375
    Duration: 6148.853 ms
     Changes:   
              ----------
              postgresql:
                  ----------
                  new:
                      10.1
                  old:
----------
          ID: postgresql-server
    Function: file.managed
        Name: /Library/LaunchAgents/homebrew.mxcl.postgresql.plist
      Result: True
     Comment: File /Library/LaunchAgents/homebrew.mxcl.postgresql.plist updated
     Started: 13:13:13.378074
    Duration: 13.146 ms
     Changes:   
              ----------
              diff:
                  New file
              mode:
                  0644
----------
          ID: postgresql-cluster-prepared
    Function: cmd.run
        Name: initdb -D /Users/messi/Library/AppSupport/postgres_homebrew
      Result: True
     Comment: Command "initdb -D /Users/messi/Library/AppSupport/postgres_homebrew" run
     Started: 13:13:13.392806
    Duration: 801.939 ms
     Changes:   
              ----------
              pid:
                  30633
              retcode:
                  0
              stderr:
                  
                  WARNING: enabling "trust" authentication for local connections
                  You can change this by editing pg_hba.conf or using the option -A, or
                  --auth-local and --auth-host, the next time you run initdb.
              stdout:
                  The files belonging to this database system will be owned by user "messi".
                  This user must also own the server process.
                  
                  The database cluster will be initialized with locale "C".
                  The default database encoding has accordingly been set to "SQL_ASCII".
                  The default text search configuration will be set to "english".
                  
                  Data page checksums are disabled.
                  
                  creating directory /Users/messi/Library/AppSupport/postgres_homebrew ... ok
                  creating subdirectories ... ok
                  selecting default max_connections ... 100
                  selecting default shared_buffers ... 128MB
                  selecting dynamic shared memory implementation ... posix
                  creating configuration files ... ok
                  running bootstrap script ... ok
                  performing post-bootstrap initialization ... ok
                  syncing data to disk ... ok
                  
                  Success. You can now start the database server using:
                  
                      pg_ctl -D /Users/messi/Library/AppSupport/postgres_homebrew -l logfile start
----------
          ID: postgresql-config-dir
    Function: file.directory
        Name: /Users/messi/Library/AppSupport/postgres_homebrew
      Result: True
     Comment: Directory /Users/messi/Library/AppSupport/postgres_homebrew updated
     Started: 13:13:19.195268
    Duration: 219.31 ms
     Changes:   
              ----------
              mode:
                  0775
----------
          ID: postgresql-conf
    Function: file.blockreplace
        Name: /Users/messi/Library/AppSupport/postgres_homebrew/postgresql.conf
      Result: True
     Comment: Changes were made
     Started: 13:13:19.414895
    Duration: 4.529 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -656,3 +656,6 @@
                   #------------------------------------------------------------------------------
                   
                   # Add settings for extensions here
                  +# Managed by SaltStack: listen_addresses: please do not edit
                  +listen_addresses = '*'  # listen on all interfaces
                  +# Managed by SaltStack: end of salt managed zone --
----------
          ID: postgresql-pg_hba
    Function: file.managed
        Name: /Users/messi/Library/AppSupport/postgres_homebrew/pg_hba.conf
      Result: True
     Comment: File /Users/messi/Library/AppSupport/postgres_homebrew/pg_hba.conf updated
     Started: 13:13:19.419582
    Duration: 3792.969 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -1,93 +1,23 @@
                  +######################################################################
                  +# ATTENTION! Managed by SaltStack.                                   #
                  +# DO NOT EDIT THIS FILE BY HAND -- YOUR CHANGES WILL BE OVERWRITTEN! #
                  +######################################################################
                  +#
                   # PostgreSQL Client Authentication Configuration File
                   # ===================================================
                   #
                   # Refer to the "Client Authentication" section in the PostgreSQL
                  -# documentation for a complete description of this file.  A short
                  -# synopsis follows.
                  -#
                  -# This file controls: which hosts are allowed to connect, how clients
                  -# are authenticated, which PostgreSQL user names they can use, which
                  -# databases they can access.  Records take one of these forms:
                  -#
                  -# local      DATABASE  USER  METHOD  [OPTIONS]
                  -# host       DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
                  -# hostssl    DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
                  -# hostnossl  DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
                  -#
                  -# (The uppercase items must be replaced by actual values.)
                  -#
                  -# The first field is the connection type: "local" is a Unix-domain
                  -# socket, "host" is either a plain or SSL-encrypted TCP/IP socket,
                  -# "hostssl" is an SSL-encrypted TCP/IP socket, and "hostnossl" is a
                  -# plain TCP/IP socket.
                  -#
                  -# DATABASE can be "all", "sameuser", "samerole", "replication", a
                  -# database name, or a comma-separated list thereof. The "all"
                  -# keyword does not match "replication". Access to replication
                  -# must be enabled in a separate record (see example below).
                  -#
                  -# USER can be "all", a user name, a group name prefixed with "+", or a
                  -# comma-separated list thereof.  In both the DATABASE and USER fields
                  -# you can also write a file name prefixed with "@" to include names
                  -# from a separate file.
                  -#
                  -# ADDRESS specifies the set of hosts the record matches.  It can be a
                  -# host name, or it is made up of an IP address and a CIDR mask that is
                  -# an integer (between 0 and 32 (IPv4) or 128 (IPv6) inclusive) that
                  -# specifies the number of significant bits in the mask.  A host name
                  -# that starts with a dot (.) matches a suffix of the actual host name.
                  -# Alternatively, you can write an IP address and netmask in separate
                  -# columns to specify the set of hosts.  Instead of a CIDR-address, you
                  -# can write "samehost" to match any of the server's own IP addresses,
                  -# or "samenet" to match any address in any subnet that the server is
                  -# directly connected to.
                  -#
                  -# METHOD can be "trust", "reject", "md5", "password", "scram-sha-256",
                  -# "gss", "sspi", "ident", "peer", "pam", "ldap", "radius" or "cert".
                  -# Note that "password" sends passwords in clear text; "md5" or
                  -# "scram-sha-256" are preferred since they send encrypted passwords.
                  -#
                  -# OPTIONS are a set of options for the authentication in the format
                  -# NAME=VALUE.  The available options depend on the different
                  -# authentication methods -- refer to the "Client Authentication"
                  -# section in the documentation for a list of which options are
                  -# available for which authentication methods.
                  -#
                  -# Database and user names containing spaces, commas, quotes and other
                  -# special characters must be quoted.  Quoting one of the keywords
                  -# "all", "sameuser", "samerole" or "replication" makes the name lose
                  -# its special character, and just match a database or username with
                  -# that name.
                  -#
                  -# This file is read on server startup and when the server receives a
                  -# SIGHUP signal.  If you edit the file on a running system, you have to
                  -# SIGHUP the server for the changes to take effect, run "pg_ctl reload",
                  -# or execute "SELECT pg_reload_conf()".
                  -#
                  -# Put your actual configuration here
                  -# ----------------------------------
                  -#
                  -# If you want to allow non-local connections, you need to add more
                  -# "host" records.  In that case you will also need to make PostgreSQL
                  -# listen on a non-local interface via the listen_addresses
                  -# configuration parameter, or via the -i or -h command line switches.
                  +# documentation for a complete description of this file.
                   
                  -# CAUTION: Configuring the system for local "trust" authentication
                  -# allows any local user to connect as any PostgreSQL user, including
                  -# the database superuser.  If you do not trust all your local users,
                  -# use another authentication method.
                  +# DO NOT DISABLE!
                  +# If you change this first entry you will need to make sure that the
                  +# database superuser can access the database using some other method.
                  +# Noninteractive access to all databases is required during automatic
                  +# maintenance (custom daily cronjobs, replication, and similar tasks).
                   
                  +# Database administrative login by Unix domain socket
                  +local   all             postgres                                peer
                   
                   # TYPE  DATABASE        USER            ADDRESS                 METHOD
                  -
                  -# "local" is for Unix domain socket connections only
                  -local   all             all                                     trust
                  -# IPv4 local connections:
                  -host    all             all             127.0.0.1/32            trust
                  -# IPv6 local connections:
                  -host    all             all             ::1/128                 trust
                  -# Allow replication connections from localhost, by a user with the
                  -# replication privilege.
                  -local   replication     all                                     trust
                  -host    replication     all             127.0.0.1/32            trust
                  -host    replication     all             ::1/128                 trust
                  +local   db1             localUser                               md5
                  +host    db2             remoteUser      192.168.33.0/24         md5
----------
          ID: postgresql-tablespace-dir-my_space
    Function: file.directory
        Name: /srv/my_tablespace
      Result: True
     Comment: Directory /srv/my_tablespace is in the correct state
              Directory /srv/my_tablespace updated
     Started: 13:13:23.212795
    Duration: 47.959 ms
     Changes:   
----------
          ID: postgresql-running
    Function: service.running
        Name: homebrew.mxcl.postgresql
      Result: True
     Comment: Service started
     Started: 13:13:23.296112
    Duration: 17.441 ms
     Changes:   
              ----------
              homebrew.mxcl.postgresql:
                  True
----------
          ID: postgresql-client-libs
    Function: pkg.installed
      Result: True
     Comment: No packages to install provided
     Started: 13:13:23.313812
    Duration: 0.447 ms
     Changes:   
----------
          ID: postgres_maxfiles_limits_conf
    Function: file.managed
        Name: /Library/LaunchDaemons/limit.maxfiles.plist
      Result: True
     Comment: File /Library/LaunchDaemons/limit.maxfiles.plist is in the correct state
     Started: 13:13:23.314350
    Duration: 2.801 ms
     Changes:   

Summary for local
-------------
Succeeded: 10 (changed=7)
Failed:     0
-------------
Total states run:     10
Total run time:   11.049 s
```
