### PR TITLE
Set env=None if cmd.run.env dict is empty

### DIFF
--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -17,7 +17,7 @@ postgres:
     test: test -f /var/lib/pgsql/data/PG_VERSION
     user: postgres
     # Be aware that there's no ``None`` value exists in YAML
-    env: Null
+    env: []
 
   conf_dir: /var/lib/pgsql/data
   postgresconf: ""

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -16,7 +16,8 @@ postgres:
     command: initdb --pgdata=/var/lib/pgsql/data
     test: test -f /var/lib/pgsql/data/PG_VERSION
     user: postgres
-    env: {}
+    # Be aware that there's no ``None`` value exists in YAML
+    env: Null
 
   conf_dir: /var/lib/pgsql/data
   postgresconf: ""

--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -56,7 +56,7 @@ postgresql-cluster-prepared:
     - name: {{ postgres.prepare_cluster.command }}
     - cwd: /
     - runas: {{ postgres.prepare_cluster.user }}
-    - env: {{ postgres.prepare_cluster.env|default({}) or None }}
+    - env: {{ postgres.prepare_cluster.env }}
     - unless:
       - {{ postgres.prepare_cluster.test }}
     - require:

--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -56,7 +56,7 @@ postgresql-cluster-prepared:
     - name: {{ postgres.prepare_cluster.command }}
     - cwd: /
     - runas: {{ postgres.prepare_cluster.user }}
-    - env: {{ postgres.prepare_cluster.env|default({}) }}
+    - env: {{ postgres.prepare_cluster.env|default({}) or None }}
     - unless:
       - {{ postgres.prepare_cluster.test }}
     - require:


### PR DESCRIPTION
This PR resolves noisy salt.cmd.run when `cmd.run.env:` is passed empty dictionary. 

` mesg: ttyname failed: Inappropriate ioctl for device`

Context is:
```
[INFO    ] Running state [pg_createcluster 9.5 main] at time 12:32:57.344486
[INFO    ] Executing state cmd.run for [pg_createcluster 9.5 main]
[INFO    ] Executing command 'test -f /var/lib/postgresql/9.5/main/PG_VERSION && test -f /etc/postgresql/9.5/main/postgresql.conf' as user 'root' in directory '/'
mesg: ttyname failed: Inappropriate ioctl for device
[DEBUG   ] output:
[DEBUG   ] Last command return code: [0]
[INFO    ] unless execution succeeded
```

Fix verified on Ubuntu.

