### PR TITLE
Env must be list, not dict, in defaults.yml

### DIFF
--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -16,7 +16,7 @@ postgres:
     command: initdb --pgdata=/var/lib/pgsql/data
     test: test -f /var/lib/pgsql/data/PG_VERSION
     user: postgres
-    env: {}
+    env: []
 
   conf_dir: /var/lib/pgsql/data
   postgresconf: ""

--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -56,7 +56,7 @@ postgresql-cluster-prepared:
     - name: {{ postgres.prepare_cluster.command }}
     - cwd: /
     - runas: {{ postgres.prepare_cluster.user }}
-    - env: {{ postgres.prepare_cluster.env|default({}) }}
+    - env: {{ postgres.prepare_cluster.env }}
     - unless:
       - {{ postgres.prepare_cluster.test }}
     - require:


### PR DESCRIPTION
Use  '`env: []`' (list) not '`env: {}`' (dict) in defaults.yaml.

(Replaces/rebases #180).