### PR TITLE
Support fromrepo in pkg.installed states

### DIFF
--- a/postgres/client.sls
+++ b/postgres/client.sls
@@ -19,11 +19,14 @@ include:
 postgresql-client-libs:
   pkg.installed:
     - pkgs: {{ pkgs }}
-{%- if postgres.use_upstream_repo %}
+  {% if postgres.fromrepo %}
+    - fromrepo: {{ postgres.fromrepo }}
+  {% endif %}
+  {%- if postgres.use_upstream_repo == true %}
     - refresh: True
     - require:
       - pkgrepo: postgresql-repo
-{%- endif %}
+  {%- endif %}
 
 {%- if 'bin_dir' in postgres %}
 

--- a/postgres/codenamemap.yaml
+++ b/postgres/codenamemap.yaml
@@ -22,6 +22,7 @@
 
 {{ codename|default(name, true) }}:
   # PostgreSQL packages are mostly downloaded from `main` repo component
+  fromrepo: {{ name }}
   pkg_repo:
     name: 'deb http://apt.postgresql.org/pub/repos/apt {{ name }}-pgdg main {{ repo.version }}'
   pkg: postgresql-{{ version }}
@@ -55,6 +56,7 @@
 
 {{ codename|default(name, true) }}:
   # PostgreSQL packages are mostly downloaded from `main` repo component
+  fromrepo: {{ name }}
   pkg_repo:
     baseurl: 'https://download.postgresql.org/pub/repos/yum/{{ version }}/fedora/fedora-$releasever-$basearch'
 
@@ -81,6 +83,9 @@
 
 ## Fedora
 # `oscodename` grain has long distro name
+{{ fedora_codename('Fedora-28', '10.3', 'Fedora 28 (Twenty Eight)') }}
+{{ fedora_codename('Fedora-27', '9.6', 'Fedora 27 (Twenty Seven)') }}
+{{ fedora_codename('Fedora-26', '9.6', 'Fedora 26 (Twenty Six)') }}
 {{ fedora_codename('Fedora-25', '9.5', 'Fedora 25 (Twenty Five)') }}
 {{ fedora_codename('Fedora-24', '9.5', 'Fedora 24 (Twenty Four)') }}
 {{ fedora_codename('Fedora-23', '9.4', 'Fedora 23 (Twenty Three)') }}

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -36,6 +36,10 @@ postgres:
 
   bake_image: False
 
+  fromrepo:
+  pkg_repo:
+    name: []
+
   users: {}
   tablespaces: {}
   databases: {}

--- a/postgres/dev.sls
+++ b/postgres/dev.sls
@@ -1,13 +1,19 @@
 {% from "postgres/map.jinja" import postgres with context %}
 
-{% if postgres.pkg_dev %}
+  {% if postgres.pkg_dev %}
 install-postgres-dev-package:
   pkg.installed:
     - name: {{ postgres.pkg_dev }}
-{% endif %}
+    {% if postgres.fromrepo %}
+    - fromrepo: {{ postgres.fromrepo }}
+    {% endif %}
+  {% endif %}
 
-{% if postgres.pkg_libpq_dev %}
+  {% if postgres.pkg_libpq_dev %}
 install-postgres-libpq-dev:
   pkg.installed:
     - name: {{ postgres.pkg_libpq_dev }}
-{% endif %}
+    {% if postgres.fromrepo %}
+    - fromrepo: {{ postgres.fromrepo }}
+    {% endif %}
+  {% endif %}

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -37,6 +37,7 @@ RedHat:
 
   {% set data_dir = '/var/lib/pgsql/' ~ repo.version ~ '/data' %}
 
+  fromrepo: pgdg{{ release }}
   pkg: postgresql{{ release }}-server
   pkg_client: postgresql{{ release }}
   conf_dir: /var/lib/pgsql/{{ repo.version }}/data

--- a/postgres/python.sls
+++ b/postgres/python.sls
@@ -2,4 +2,15 @@
 
 postgresql-python:
   pkg.installed:
-    - name: {{ postgres.python}}
+    - name: {{ postgres.pkg_python}}
+  {% if postgres.fromrepo %}
+    - fromrepo: {{ postgres.fromrepo }}
+  {% endif %}
+  {% if postgres.use_upstream_repo == true %}
+    - refresh: True
+    - require:
+      - pkgrepo: postgresql-repo
+
+include:
+  - postgres.upstream
+  {% endif %}

--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -22,11 +22,11 @@ include:
 postgresql-server:
   pkg.installed:
     - pkgs: {{ pkgs }}
-{%- if postgres.use_upstream_repo %}
+  {%- if postgres.use_upstream_repo == true %}
     - refresh: True
     - require:
       - pkgrepo: postgresql-repo
-{%- endif %}
+  {%- endif %}
 
 {%- if 'bin_dir' in postgres %}
 

--- a/postgres/upstream.sls
+++ b/postgres/upstream.sls
@@ -3,7 +3,7 @@
 
 {%- if 'pkg_repo' in postgres -%}
 
-  {%- if postgres.use_upstream_repo -%}
+  {%- if postgres.use_upstream_repo == true -%}
 
 # Add upstream repository for your distro
 postgresql-repo:
@@ -22,7 +22,7 @@ postgresql-repo:
 
   {%- endif -%}
 
-{%- else -%}
+{%- elif grains.os not in ('Windows', 'MacOS',) %}
 
 # Notify that we don't manage this distro
 postgresql-repo:


### PR DESCRIPTION
This PR fixes a bug around repo handling.  

When `packagename` exists in multiple repo, setting `use_upstream_repo: True` cannot guarantee upstream package gets installed.  This bug was noticed while testing #176 on openSuse with upstream `version: 9.6`.   

Also resolves #133 
