### PR TITLE
allow for separate configuration and data directories

### DIFF
--- a/postgres/codenamemap.yaml
+++ b/postgres/codenamemap.yaml
@@ -27,9 +27,10 @@
   pkg: postgresql-{{ version }}
   pkg_client: postgresql-client-{{ version }}
   conf_dir: /etc/postgresql/{{ version }}/main
+  data_dir: /var/lib/postgresql/{{ version }}/main
   prepare_cluster:
-    command: pg_createcluster {{ version }} main
-    test: test -f /var/lib/postgresql/{{ version }}/main/PG_VERSION && test -f /etc/postgresql/{{ version }}/main/postgresql.conf
+    pgcommand: pg_createcluster {{ version }} main -d
+    pgtestfile: PG_VERSION
     user: root
 
 {% endmacro %}

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -7,19 +7,37 @@ postgres:
   pkgs_extra: []
   pkg_client: postgresql-client
   pkg_dev: postgresql-devel
-  pkg_libpq_dev: postgresql-libs
-  python: python-psycopg2
+  pkg_libpq_dev: libpq-dev
+  pkg_libs: postgresql-libs
+  pkg_python: python-psycopg2
+  userhomes: /home
   user: postgres
   group: postgres
 
+  conf_dir: /var/lib/pgsql/data
+  data_dir: /var/lib/pgsql/data
   prepare_cluster:
-    command: initdb --pgdata=/var/lib/pgsql/data
-    test: test -f /var/lib/pgsql/data/PG_VERSION
+    pgcommand: initdb --pgdata=
+    pgtestfile: PG_VERSION
     user: postgres
     env: []
 
-  conf_dir: /var/lib/pgsql/data
   postgresconf: ""
+
+  macos:
+    archive: postgres.dmg
+    tmpdir: /tmp/postgrestmp
+    postgresapp:
+      #See: https://github.com/PostgresApp/PostgresApp/releases/
+      url: https://github.com/PostgresApp/PostgresApp/releases/download/v2.1.1/Postgres-2.1.1.dmg
+      sum: sha256=ac0656b522a58fd337931313f09509c09610c4a6078fe0b8e469e69af1e1750b
+    homebrew:
+      url:
+      sum:
+    dl:
+      opts: -s -L
+      interval: 60
+      retries: 2
 
   pg_hba.conf: salt://postgres/templates/pg_hba.conf.j2
   acls:

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -4,9 +4,10 @@
 
 Arch:
   conf_dir: /var/lib/postgres/data
+  data_dir: /var/lib/postgres/data
   prepare_cluster:
-    command: initdb -D /var/lib/postgres/data
-    test: test -f /var/lib/postgres/data/PG_VERSION
+    pgcommand: initdb -D
+    pgtestfile: PG_VERSION
   pkg_client: postgresql-libs
   pkg_dev: postgresql
 
@@ -17,12 +18,13 @@ Debian:
     file: /etc/apt/sources.list.d/pgdg.list
   pkg_repo_keyid: ACCC4CF8
   pkg_dev: postgresql-server-dev-all
-  pkg_libpq_dev: libpq-dev
 
 FreeBSD:
   user: pgsql
 
 OpenBSD:
+  conf_dir: /var/postgresql/data
+  data_dir: /var/postgresql/data
   user: _postgresql
 
 RedHat:
@@ -33,18 +35,20 @@ RedHat:
     gpgcheck: 1
     gpgkey: 'https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-{{ release }}'
 
-{% if repo.use_upstream_repo %}
-
+{% if repo.use_upstream_repo == true %}
   {% set data_dir = '/var/lib/pgsql/' ~ repo.version ~ '/data' %}
 
   pkg: postgresql{{ release }}-server
   pkg_client: postgresql{{ release }}
-  conf_dir: /var/lib/pgsql/{{ repo.version }}/data
+  pkg_libs: postgresql{{ release }}-libs
+  pkg_dev: postgresql{{ release }}-devel
+  conf_dir: {{ data_dir }}
+  data_dir: {{ data_dir }}
   service: postgresql-{{ repo.version }}
 
   prepare_cluster:
-    command: initdb --pgdata='{{ data_dir }}'
-    test: test -f '{{ data_dir }}/PG_VERSION'
+    pgcommand: initdb --pgdata=
+    pgtestfile: PG_VERSION
 
   # Directory containing PostgreSQL client executables
   bin_dir: /usr/pgsql-{{ repo.version }}/bin
@@ -89,25 +93,87 @@ RedHat:
   pkg_client: postgresql
 
 {% endif %}
+  pkg_libpq_dev: libpqxx-devel
 
 Suse:
+  pkg_repo:
+    name: pgdg-sles-{{ release }}
+    humanname: PostgreSQL {{ repo.version }} $releasever - $basearch
+    #Using sles-12 upstream repo for opensuse
+    baseurl: 'https://download.postgresql.org/pub/repos/zypp/{{ repo.version }}/suse/sles-12-$basearch'
+    key_url: 'https://download.postgresql.org/pub/repos/zypp/{{ repo.version }}/suse/sles-12-$basearch/repodata/repomd.xml.key'
+    gpgcheck: 1
+    gpgautoimport: True
+
+{% if repo.use_upstream_repo == true %}
+  {% set lib_dir = '/var/lib/pgsql/' ~ repo.version ~ '/data' %}
+
+  pkg: postgresql{{ release }}-server
+  pkg_client: postgresql{{ release }}
+  pkg_dev: postgresql{{ release }}-devel
+  pkg_libs: postgresql{{ release }}-libs
+  conf_dir: {{ lib_dir }}
+  service: postgresql-{{ repo.version }}
+
+  prepare_cluster:
+    command: /usr/pgsql-{{ repo.version }}/bin/initdb --pgdata='{{ lib_dir }}'
+    test: test -f '{{ lib_dir }}/PG_VERSION'
+
+  # Alternatives system
+  linux:
+    altpriority: 30
+
+  # directory containing PostgreSQL client executables
+  bin_dir: /usr/pgsql-{{ repo.version }}/bin
+  client_bins:
+    - pg_archivecleanup
+    - pg_config
+    - pg_isready
+    - pg_receivexlog
+    - pg_rewind
+    - pg_test_fsync
+    - pg_test_timing
+    - pg_upgrade
+    - pg_xlogdump
+    - pgbench
+  server_bins:
+    - initdb
+    - pg_controldata
+    - pg_ctl
+    - pg_resetxlog
+    - postgres
+    - postgresql{{ release }}-check-db-dir
+    - postgresql{{ release }}-setup
+    - postmaster
+
+{% else %}
+
   pkg: postgresql-server
   pkg_client: postgresql
-  pkg_libpq_dev: postgresql
 
+{% endif %}
+  pkg_libpq_dev: libqpxx
+
+{%- if grains.os == 'MacOS' %}
+## jinja check avoids rendering noise/failure on Linux
 MacOS:
-  service: postgresql
+   {%- if repo.use_upstream_repo == 'homebrew' %}
+  service: homebrew.mxcl.postgresql
+   {%- elif repo.use_upstream_repo == 'postgresapp' %}
+  service: com.postgresapp.Postgres2
+   {%- endif %}
   pkg: postgresql
   pkg_client:
   pkg_libpq_dev:
-  conf_dir: /usr/local/var/postgres
-  user: _postgres
-  group: _postgres
+  userhomes: /Users
+  user: {{ repo.user }}
+  group: {{ repo.group }}
+  conf_dir: /Users/{{ repo.user }}/Library/AppSupport/postgres_{{ repo.use_upstream_repo }}
   prepare_cluster:
-    command: initdb -D /usr/local/var/postgres/
-    test: test -f /usr/local/var/postgres/PG_VERSION
-    user: _postgres
-    group: _postgres
-
+    command: initdb -D /Users/{{ repo.user }}/Library/AppSupport/postgres_{{ repo.use_upstream_repo }}
+    test: test -f /Users/{{ repo.user }}/Library/AppSupport/postgres_{{ repo.use_upstream_repo }}/PG_VERSION
+    user: {{ repo.user }}
+    group: {{ repo.group }}
+{%- endif %}
 
 # vim: ft=sls

--- a/postgres/python.sls
+++ b/postgres/python.sls
@@ -2,4 +2,4 @@
 
 postgresql-python:
   pkg.installed:
-    - name: {{ postgres.python}}
+    - name: {{ postgres.pkg_python}}

--- a/postgres/server/image.sls
+++ b/postgres/server/image.sls
@@ -12,10 +12,10 @@ include:
 
 postgresql-start:
   cmd.run:
-    - name: pg_ctl -D {{ postgres.conf_dir }} -l logfile start
+    - name: pg_ctl -D {{ postgres.data_dir }} -l logfile start
     - runas: {{ postgres.user }}
     - unless:
-      - ps -p $(head -n 1 {{ postgres.conf_dir }}/postmaster.pid) 2>/dev/null
+      - ps -p $(head -n 1 {{ postgres.data_dir }}/postmaster.pid) 2>/dev/null
     - require:
       - file: postgresql-pg_hba
 

--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -52,21 +52,41 @@ postgresql-server:
 {%- endif %}
 
 postgresql-cluster-prepared:
+  file.directory:
+    # The next state runs as unprivledged user but "unless" check needs privledge.
+    # This state ensures "cmd.run.unless='test -f data_dir/PG_VERSION'" works below.
+    - name: {{ postgres.data_dir }}
+    - dir_mode: 0755
+    - onlyif: test -f {{ postgres.data_dir }}/{{ postgres.prepare_cluster.pgtestfile }}
   cmd.run:
+ {%- if postgres.prepare_cluster.command is defined %}
+      {# support for depreciated 'prepare_cluster.command' pillar #}
     - name: {{ postgres.prepare_cluster.command }}
+    - unless: {{ postgres.prepare_cluster.test }}
+ {%- else %}
+    - name: {{ postgres.prepare_cluster.pgcommand + ' ' }} {{ postgres.data_dir }}
+    - unless: test -f {{ postgres.data_dir }}/{{ postgres.prepare_cluster.pgtestfile }}
+ {%- endif %}
     - cwd: /
     - runas: {{ postgres.prepare_cluster.user }}
     - env: {{ postgres.prepare_cluster.env }}
-    - unless:
-      - {{ postgres.prepare_cluster.test }}
     - require:
+      - file: postgresql-cluster-prepared
       - pkg: postgresql-server
 
 postgresql-config-dir:
   file.directory:
-    - name: {{ postgres.conf_dir }}
+    - names:
+      - {{ postgres.data_dir }}
+      - {{ postgres.conf_dir }}
     - user: {{ postgres.user }}
     - group: {{ postgres.group }}
+    - dir_mode: 0700
+    - force: True
+    - file_mode: 644
+    - recurse:
+      - user
+      - group
     - makedirs: True
     - require:
       - cmd: postgresql-cluster-prepared


### PR DESCRIPTION
This PR allows different "configuration" and "data" directory, resolving some issues-

1. Ubuntu postgresql-server stores config in `/etc`, and data into `/var`.  The `postgres` state fails horribly if `/etc/postgresql/../postgresql.conf` exists, perhaps after `postgres.dropped` runs. 

2. User may want separation of data and configuration.

3. This is **current situation** where `conf_dir` variable exists but not `data_dir`.
```
codenamemap.yaml:  conf_dir: /etc/postgresql/{{ version }}/main
defaults.yaml:  conf_dir: /var/lib/pgsql/data
osmap.yaml:  conf_dir: /var/lib/postgres/data
osmap.yaml:  conf_dir: /var/lib/pgsql/{{ repo.version }}/data
osmap.yaml:  conf_dir: /usr/local/var/postgres
```

4. `postgres` install always fails after 'dropped' (or remove #182) states, because conf_dir remains.

5. If `conf_dir` and `data_dir` have same value, `pg_ctl` throws permissions error.

`pg_ctl[8774]: FATAL:  data directory "/var/lib/pgsql/data" has group or world access`