### PR TITLE
Do not fail states during mock test mode

### DIFF
--- a/postgres/macros.jinja
+++ b/postgres/macros.jinja
@@ -23,6 +23,8 @@
 {{ state }}-{{ name }}:
   {{ state }}.{{ ensure|default('present') }}:
     {{- format_kwargs(kwarg) }}
+    - onchanges:
+      - test: postgres-reload-modules
 
 {%- endmacro %}
 


### PR DESCRIPTION
The key purpose of this PR is to be able to test and debug rendering `postgres` states.
It makes mocked test run (`salt-call state.apply postgres mock=True`) return success if Pillar data, defaults and Jinja logic are syntactically valid.
The only problem with `postgres.manage` SLS is that the states would always fail until PG client binaries would be installed.

This could be simply fixed by forcing `postgres-reload-modules` state always produce changes and subscribe on those. Since "mocked" test does not generate any changes, we will get success. That means the code is valid, although may be logically incorrect.

@javierbertoli Would you be able to review this, please? Thank you in advance.