### PR TITLE
PostgresApp and Homebrew Postgres on MacOS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,12 +17,12 @@ Available states
 ------------
 
 Installs and configures both PostgreSQL server and client with creation of various DB objects in
-the cluster.
+the cluster. This state applies to both Linux and MacOS.
 
 ``postgres.client``
 -------------------
 
-Installs the PostgreSQL client binaries and libraries.
+Installs the PostgreSQL client binaries and libraries on Linux.
 
 ``postgres.manage``
 -------------------
@@ -33,18 +33,18 @@ See ``pillar.example`` file for details.
 ``postgres.python``
 -------------------
 
-Installs the PostgreSQL adapter for Python.
+Installs the PostgreSQL adapter for Python on Linux.
 
 ``postgres.server``
 -------------------
 
-Installs the PostgreSQL server package, prepares the DB cluster and starts the server using
+Installs the PostgreSQL server package on Linux, prepares the DB cluster and starts the server using
 packaged init script, job or unit.
 
 ``postgres.server.image``
 -------------------------
 
-Installs the PostgreSQL server package, prepares the DB cluster and starts the server by issuing
+Installs the PostgreSQL server package on Linux, prepares the DB cluster and starts the server by issuing
 raw ``pg_ctl`` command. The ``postgres:bake_image`` Pillar toggles this behaviour. For example:
 
 .. code:: yaml
@@ -77,12 +77,14 @@ The state relies on the ``postgres:use_upstream_repo`` Pillar value which could 
 
 * ``True`` (default): adds the upstream repository to install packages from
 * ``False``: makes sure that the repository configuration is absent
+* ``postgresapp`` (MacOS) uses upstream PostgresApp package repository.
 
 The ``postgres:version`` Pillar controls which version of the PostgreSQL packages should be
-installed from the upstream repository. Defaults to ``9.5``.
+installed from the upstream Linux repository. Defaults to ``9.5``.
 
 Testing
 =======
+The postgres state was tested on MacOS (El Capitan 10.11.6)
 
 Testing is done with the ``kitchen-salt``.
 

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,8 @@ The state relies on the ``postgres:use_upstream_repo`` Pillar value which could 
 
 * ``True`` (default): adds the upstream repository to install packages from
 * ``False``: makes sure that the repository configuration is absent
-* ``postgresapp`` (MacOS) uses upstream PostgresApp package repository.
+* ``'postgresapp'`` (MacOS) uses upstream PostgresApp package repository.
+* ``'homebrew'`` (MacOS) uses Homebrew postgres
 
 The ``postgres:version`` Pillar controls which version of the PostgreSQL packages should be
 installed from the upstream Linux repository. Defaults to ``9.5``.

--- a/pillar.example
+++ b/pillar.example
@@ -6,8 +6,9 @@ postgres:
   version: '9.6'
 
   ### MACOS
-  # Set to 'postgresapp' to install that upstream MacOS package
+  # Set to 'postgresapp' OR 'homebrew' for MacOS
   #use_upstream_repo: 'postgresapp'
+  #use_upstream_repo: 'homebrew'
 
   # PACKAGE
   # These pillars are typically never required.

--- a/pillar.example
+++ b/pillar.example
@@ -5,6 +5,10 @@ postgres:
   # Version to install from upstream repository (if upstream_repo: True)
   version: '9.6'
 
+  ### MACOS
+  # Set to 'postgresapp' to install that upstream MacOS package
+  #use_upstream_repo: 'postgresapp'
+
   # PACKAGE
   # These pillars are typically never required.
   # pkg: 'postgresql'
@@ -14,10 +18,14 @@ postgres:
     - postgresql-contrib
     - postgresql-plpython
 
-
   #'Alternatives system' priority incremental. 0 disables feature.
   linux:
     altpriority: 30
+
+  # macos limits
+  limits:
+    soft: 64000
+    hard: 64000
 
   # POSTGRES
   # Append the lines under this item to your postgresql.conf file.

--- a/postgres/client.sls
+++ b/postgres/client.sls
@@ -7,7 +7,7 @@
   {%- endif %}
 {%- endfor %}
 
-{%- if postgres.use_upstream_repo %}
+{%- if postgres.use_upstream_repo == true %}
 include:
   - postgres.upstream
 {%- endif %}
@@ -16,7 +16,7 @@ include:
 postgresql-client-libs:
   pkg.installed:
     - pkgs: {{ pkgs }}
-{%- if postgres.use_upstream_repo %}
+{%- if postgres.use_upstream_repo == true %}
     - refresh: True
     - require:
       - pkgrepo: postgresql-repo

--- a/postgres/codenamemap.yaml
+++ b/postgres/codenamemap.yaml
@@ -16,7 +16,7 @@
   #}
 
   {# use upstream version if configured #}
-  {% if repo.use_upstream_repo %}
+  {% if repo.use_upstream_repo == true %}
     {% set version = repo.version %}
   {% endif %}
 
@@ -49,7 +49,7 @@
   #}
 
   {# use upstream version if configured #}
-  {% if repo.use_upstream_repo %}
+  {% if repo.use_upstream_repo == true %}
     {% set version = repo.version %}
   {% endif %}
 

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -9,6 +9,8 @@ postgres:
   pkg_dev: postgresql-devel
   pkg_libpq_dev: postgresql-libs
   python: python-psycopg2
+  userhomes: /home
+  systemuser:
   user: postgres
   group: postgres
 
@@ -20,6 +22,21 @@ postgres:
 
   conf_dir: /var/lib/pgsql/data
   postgresconf: ""
+
+  macos:
+    archive: postgres.dmg
+    tmpdir: /tmp/postgrestmp
+    postgresapp:
+      #See: https://github.com/PostgresApp/PostgresApp/releases/
+      url: https://github.com/PostgresApp/PostgresApp/releases/download/v2.1.1/Postgres-2.1.1.dmg
+      sum: sha256=ac0656b522a58fd337931313f09509c09610c4a6078fe0b8e469e69af1e1750b
+    homebrew:
+      url:
+      sum:
+    dl:
+      opts: -s -L
+      interval: 60
+      retries: 2
 
   pg_hba.conf: salt://postgres/templates/pg_hba.conf.j2
   acls:

--- a/postgres/dev.sls
+++ b/postgres/dev.sls
@@ -1,13 +1,61 @@
 {% from "postgres/map.jinja" import postgres with context %}
 
-{% if postgres.pkg_dev %}
+{% if grains.os not in ('Windows', 'MacOS',) %}
+
+  {% if postgres.pkg_dev %}
 install-postgres-dev-package:
   pkg.installed:
     - name: {{ postgres.pkg_dev }}
-{% endif %}
+  {% endif %}
 
-{% if postgres.pkg_libpq_dev %}
+  {% if postgres.pkg_libpq_dev %}
 install-postgres-libpq-dev:
   pkg.installed:
     - name: {{ postgres.pkg_libpq_dev }}
+  {% endif %}
+
+{% endif %}
+
+
+{% if grains.os == 'MacOS' %}
+
+  # Darwin maxfiles limits
+  {% if postgres.limits.soft or postgres.limits.hard %}
+
+postgres_maxfiles_limits_conf:
+  file.managed:
+    - name: /Library/LaunchDaemons/limit.maxfiles.plist
+    - source: salt://postgres/templates/limit.maxfiles.plist
+    - context:
+      soft_limit: {{ postgres.limits.soft or postgres.limits.hard }}
+      hard_limit: {{ postgres.limits.hard or postgres.limits.soft }}
+    - group: wheel
+  {% endif %}
+
+  # MacOS Shortcut for system user
+  {% if postgres.systemuser|lower not in (None, '',) %}
+
+postgres-desktop-shortcut-clean:
+  file.absent:
+    - name: '{{ postgres.userhomes }}/{{ postgres.systemuser }}/Desktop/postgres'
+    - require_in:
+      - file: postgres-desktop-shortcut-add
+
+  {% endif %}
+
+postgres-desktop-shortcut-add:
+  file.managed:
+    - name: /tmp/mac_shortcut.sh
+    - source: salt://postgres/templates/mac_shortcut.sh
+    - mode: 755
+    - template: jinja
+    - context:
+      user: {{ postgres.systemuser }}
+      homes: {{ postgres.userhomes }}
+  cmd.run:
+    - name: /tmp/mac_shortcut.sh {{ postgres.use_upstream_repo }}
+    - runas: {{ postgres.systemuser }}
+    - require:
+      - file: postgres-desktop-shortcut-add
+
 {% endif %}

--- a/postgres/dev.sls
+++ b/postgres/dev.sls
@@ -29,19 +29,16 @@ postgres_maxfiles_limits_conf:
     - context:
       soft_limit: {{ postgres.limits.soft or postgres.limits.hard }}
       hard_limit: {{ postgres.limits.hard or postgres.limits.soft }}
-    - group: wheel
+    - group: {{ postgres.group }}
   {% endif %}
 
-  # MacOS Shortcut for system user
-  {% if postgres.systemuser|lower not in (None, '',) %}
-
+  {% if postgres.use_upstream_repo == 'postgresapp' %}
+  # Shortcut for PostgresApp
 postgres-desktop-shortcut-clean:
   file.absent:
-    - name: '{{ postgres.userhomes }}/{{ postgres.systemuser }}/Desktop/postgres'
+    - name: '{{ postgres.userhomes }}/{{ postgres.user }}/Desktop/Postgres ({{ postgres.use_upstream_repo }})'
     - require_in:
       - file: postgres-desktop-shortcut-add
-
-  {% endif %}
 
 postgres-desktop-shortcut-add:
   file.managed:
@@ -50,12 +47,13 @@ postgres-desktop-shortcut-add:
     - mode: 755
     - template: jinja
     - context:
-      user: {{ postgres.systemuser }}
+      user: {{ postgres.user }}
       homes: {{ postgres.userhomes }}
   cmd.run:
-    - name: /tmp/mac_shortcut.sh {{ postgres.use_upstream_repo }}
-    - runas: {{ postgres.systemuser }}
+    - name: '/tmp/mac_shortcut.sh "Postgres ({{ postgres.use_upstream_repo }})"'
+    - runas: {{ postgres.user }}
     - require:
       - file: postgres-desktop-shortcut-add
+  {% endif %}
 
 {% endif %}

--- a/postgres/init.sls
+++ b/postgres/init.sls
@@ -1,4 +1,9 @@
+
 include:
+{% if grains.os == 'MacOS' %}
+  - postgres.macos
+{% else %}
   - postgres.server
   - postgres.client
   - postgres.manage
+{% endif %}

--- a/postgres/macos/init.sls
+++ b/postgres/macos/init.sls
@@ -1,0 +1,10 @@
+{% from "postgres/map.jinja" import postgres with context %}
+
+include:
+{% if postgres.use_upstream_repo == 'postgresapp' %}
+  - postgres.macos.postgresapp
+{% else %}
+  - postgres.server
+  - postgres.client
+{% endif %}
+  - postgres.dev

--- a/postgres/macos/init.sls
+++ b/postgres/macos/init.sls
@@ -3,7 +3,7 @@
 include:
 {% if postgres.use_upstream_repo == 'postgresapp' %}
   - postgres.macos.postgresapp
-{% else %}
+{% elif postgres.use_upstream_repo == 'homebrew' %}
   - postgres.server
   - postgres.client
 {% endif %}

--- a/postgres/macos/postgresapp.sls
+++ b/postgres/macos/postgresapp.sls
@@ -27,9 +27,7 @@ pg-download-archive:
         interval: {{ pg.macos.dl.interval }}
       {% endif %}
 
-{%- if pg.macos.postgresapp.sum %}
-   #Check hashstring for archive downloads
-  {%- if grains['saltversioninfo'] <= [2016, 11, 6] %}
+  {%- if pg.macos.postgresapp.sum %}
 pg-check-archive-hash:
    module.run:
      - name: file.check_hash
@@ -40,7 +38,6 @@ pg-check-archive-hash:
      - require_in:
        - archive: pg-package-install
   {%- endif %}
-{%- endif %}
 
 pg-package-install:
   macpackage.installed:
@@ -56,7 +53,7 @@ pg-package-install:
       - file: pg-package-install
       - file: pg-remove-archive
   file.append:
-    - name: {{ pg.userhomes }}/{{ pg.systemuser }}/.bash_profile
+    - name: {{ pg.userhomes }}/{{ pg.user }}/.bash_profile
     - text: 'export PATH=$PATH:/Applications/Postgres.app/Contents/Versions/latest/bin'
 
 pg-remove-archive:

--- a/postgres/macos/postgresapp.sls
+++ b/postgres/macos/postgresapp.sls
@@ -1,0 +1,67 @@
+{% from "postgres/map.jinja" import postgres as pg with context %}
+
+# Cleanup first
+pg-remove-prev-archive:
+  file.absent:
+    - name: '{{ pg.macos.tmpdir }}/{{ pg.macos.archive }}'
+    - require_in:
+      - pg-extract-dirs
+
+pg-extract-dirs:
+  file.directory:
+    - names:
+      - '{{ pg.macos.tmpdir }}'
+    - makedirs: True
+    - clean: True
+    - require_in:
+      - pg-download-archive
+
+pg-download-archive:
+  pkg.installed:
+    - name: curl
+  cmd.run:
+    - name: curl {{ pg.macos.dl.opts }} -o '{{ pg.macos.tmpdir }}/{{ pg.macos.archive }}' {{ pg.macos.postgresapp.url }}
+      {% if grains['saltversioninfo'] >= [2017, 7, 0] %}
+    - retry:
+        attempts: {{ pg.macos.dl.retries }}
+        interval: {{ pg.macos.dl.interval }}
+      {% endif %}
+
+{%- if pg.macos.postgresapp.sum %}
+   #Check hashstring for archive downloads
+  {%- if grains['saltversioninfo'] <= [2016, 11, 6] %}
+pg-check-archive-hash:
+   module.run:
+     - name: file.check_hash
+     - path: '{{ pg.macos.tmpdir }}/{{ pg.macos.archive }}'
+     - file_hash: {{ pg.macos.postgresapp.sum }}
+     - onchanges:
+       - cmd: pg-download-archive
+     - require_in:
+       - archive: pg-package-install
+  {%- endif %}
+{%- endif %}
+
+pg-package-install:
+  macpackage.installed:
+    - name: '{{ pg.macos.tmpdir }}/{{ pg.macos.archive }}'
+    - store: True
+    - dmg: True
+    - app: True
+    - force: True
+    - allow_untrusted: True
+    - onchanges:
+      - cmd: pg-download-archive
+    - require_in:
+      - file: pg-package-install
+      - file: pg-remove-archive
+  file.append:
+    - name: {{ pg.userhomes }}/{{ pg.systemuser }}/.bash_profile
+    - text: 'export PATH=$PATH:/Applications/Postgres.app/Contents/Versions/latest/bin'
+
+pg-remove-archive:
+  file.absent:
+    - name: '{{ pg.macos.tmpdir }}'
+    - onchanges:
+      - macpackage: pg-package-install
+

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -33,7 +33,7 @@ RedHat:
     gpgcheck: 1
     gpgkey: 'https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-{{ release }}'
 
-{% if repo.use_upstream_repo %}
+{% if repo.use_upstream_repo == true %}
 
   {% set data_dir = '/var/lib/pgsql/' ~ repo.version ~ '/data' %}
 
@@ -104,7 +104,7 @@ Suse:
     gpgcheck: 1
     gpgautoimport: True
 
-{% if repo.use_upstream_repo %}
+{% if repo.use_upstream_repo == true %}
   {# Pillars needed are 'use_upstream_repo: True' and 'version: n.n'. #}
   {# Avoid setting package names as pillars, as may corrupt postgres. #}
   {% set lib_dir = '/var/lib/pgsql/' ~ repo.version ~ '/data' %}
@@ -133,13 +133,14 @@ Suse:
 
 {% endif %}
 
+{%- if grains.os == 'MacOS' %}
+## jinja check avoids rendering noise/failure on Linux
 MacOS:
-   {# todo: homebrew postgresql #}
-   {% if repo.use_upstream_repo == 'homebrew' %}
+   {%- if repo.use_upstream_repo == 'homebrew' %}
   service: homebrew.mxcl.postgresql
-   {% elif repo.use_upstream_repo == 'postgresapp' %}
+   {%- elif repo.use_upstream_repo == 'postgresapp' %}
   service: com.postgresapp.Postgres2
-    {% endif %}
+   {%- endif %}
   pkg: postgresql
   pkg_client:
   pkg_libpq_dev:
@@ -152,5 +153,6 @@ MacOS:
     test: test -f /Users/{{ repo.user }}/Library/AppSupport/postgres_{{ repo.use_upstream_repo }}/PG_VERSION
     user: {{ repo.user }}
     group: {{ repo.group }}
+{%- endif %}
 
 # vim: ft=sls

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -134,17 +134,23 @@ Suse:
 {% endif %}
 
 MacOS:
-  service: postgresql
+   {# todo: homebrew postgresql #}
+   {% if repo.use_upstream_repo == 'homebrew' %}
+  service: homebrew.mxcl.postgresql
+   {% elif repo.use_upstream_repo == 'postgresapp' %}
+  service: com.postgresapp.Postgres2
+    {% endif %}
   pkg: postgresql
   pkg_client:
   pkg_libpq_dev:
-  conf_dir: /usr/local/var/postgres
-  user: _postgres
-  group: _postgres
+  userhomes: /Users
+  user: {{ repo.user }}
+  group: {{ repo.group }}
+  conf_dir: /Users/{{ repo.user }}/Library/AppSupport/postgres_{{ repo.use_upstream_repo }}
   prepare_cluster:
-    command: initdb -D /usr/local/var/postgres/
-    test: test -f /usr/local/var/postgres/PG_VERSION
-    user: _postgres
-    group: _postgres
+    command: initdb -D /Users/{{ repo.user }}/Library/AppSupport/postgres_{{ repo.use_upstream_repo }}
+    test: test -f /Users/{{ repo.user }}/Library/AppSupport/postgres_{{ repo.use_upstream_repo }}/PG_VERSION
+    user: {{ repo.user }}
+    group: {{ repo.group }}
 
 # vim: ft=sls

--- a/postgres/repo.yaml
+++ b/postgres/repo.yaml
@@ -8,4 +8,12 @@ use_upstream_repo: {{ salt['pillar.get']('postgres:use_upstream_repo',
 version: {{ salt['pillar.get']('postgres:version',
                                defaults.postgres.version) }}
 
+#Early lookup for system user on MacOS
+{% if grains.os == 'MacOS' %}
+  {% set sysuser = salt['pillar.get']('postgres.user') or salt['cmd.run']("stat -f '%Su' /dev/console") %}
+  {% set sysgroup = salt['pillar.get']('postgres.group') or salt['cmd.run']("stat -f '%Sg' /dev/console") %}
+user: {{ sysuser }}
+group: {{ sysgroup }}
+{% endif %}
+
 # vim: ft=sls

--- a/postgres/templates/limit.maxfiles.plist
+++ b/postgres/templates/limit.maxfiles.plist
@@ -7,7 +7,7 @@
     <string>limit.maxfiles</string>
     <key>ProgramArguments</key>
     <array>
-      <string>launchctl</string>
+      <string>/bin/launchctl</string>
       <string>limit</string>
       <string>maxfiles</string>
       <string>{{ soft_limit }}</string>

--- a/postgres/templates/limit.maxfiles.plist
+++ b/postgres/templates/limit.maxfiles.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>  
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"  
+        "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">  
+  <dict>
+    <key>Label</key>
+    <string>limit.maxfiles</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>launchctl</string>
+      <string>limit</string>
+      <string>maxfiles</string>
+      <string>{{ soft_limit }}</string>
+      <string>{{ hard_limit }}</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>ServiceIPC</key>
+    <false/>
+  </dict>
+</plist> 

--- a/postgres/templates/mac_shortcut.sh
+++ b/postgres/templates/mac_shortcut.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-vendor=$1
+shortcutName='${1}'
 app="postgres.app"
 Source="/Applications/$app"
-Destination="{{ homes }}/{{ user }}/Desktop"
+Destination="{{ homes }}/{{ user }}/Desktop/${shortcutName}"
 /usr/bin/osascript -e "tell application \"Finder\" to make alias file to POSIX file \"$Source\" at POSIX file \"$Destination\""
 

--- a/postgres/templates/mac_shortcut.sh
+++ b/postgres/templates/mac_shortcut.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+vendor=$1
+app="postgres.app"
+Source="/Applications/$app"
+Destination="{{ homes }}/{{ user }}/Desktop"
+/usr/bin/osascript -e "tell application \"Finder\" to make alias file to POSIX file \"$Source\" at POSIX file \"$Destination\""
+

--- a/postgres/upstream.sls
+++ b/postgres/upstream.sls
@@ -3,7 +3,7 @@
 
 {%- if 'pkg_repo' in postgres -%}
 
-  {%- if postgres.use_upstream_repo -%}
+  {%- if postgres.use_upstream_repo == true -%}
 
 # Add upstream repository for your distro
 postgresql-repo:
@@ -25,9 +25,11 @@ postgresql-repo:
 {%- else -%}
 
 # Notify that we don't manage this distro
+  {% if grains.os not in ('Windows', 'MacOS',) %}
 postgresql-repo:
   test.show_notification:
     - text: |
         PostgreSQL does not provide package repository for {{ grains['osfinger'] }}
+  {% endif %}
 
 {%- endif %}


### PR DESCRIPTION
Support `PostgresApp` and `Homebrew Postgres` on MacOS.  

*** POSTGRESAPP ***
```
local:
----------
          ID: pg-remove-prev-archive
    Function: file.absent
        Name: /tmp/postgrestmp/postgres.dmg
      Result: True
     Comment: Removed file /tmp/postgrestmp/postgres.dmg
     Started: 10:26:44.473380
    Duration: 11.411 ms
     Changes:   
              ----------
              removed:
                  /tmp/postgrestmp/postgres.dmg
----------
          ID: pg-extract-dirs
    Function: file.directory
        Name: /tmp/postgrestmp
      Result: True
     Comment: Directory /tmp/postgrestmp is in the correct state
              Directory /tmp/postgrestmp updated
     Started: 10:26:44.484917
    Duration: 0.752 ms
     Changes:   
----------
          ID: pg-download-archive
    Function: pkg.installed
        Name: curl
      Result: True
     Comment: Package curl is already installed
     Started: 10:26:46.269667
    Duration: 733.215 ms
     Changes:   
----------
          ID: pg-download-archive
    Function: cmd.run
        Name: curl -s -L -o '/tmp/postgrestmp/postgres.dmg' https://github.com/PostgresApp/PostgresApp/releases/download/v2.1.1/Postgres-2.1.1.dmg
      Result: True
     Comment: Command "curl -s -L -o '/tmp/postgrestmp/postgres.dmg' https://github.com/PostgresApp/PostgresApp/releases/download/v2.1.1/Postgres-2.1.1.dmg" run
     Started: 10:26:47.005116
    Duration: 229067.193 ms
     Changes:   
              ----------
              pid:
                  5116
              retcode:
                  0
              stderr:
              stdout:
----------
          ID: pg-package-install
    Function: macpackage.installed
        Name: /tmp/postgrestmp/postgres.dmg
      Result: True
     Comment: Postgres.app installed
     Started: 10:30:36.295101
    Duration: 18240.587 ms
     Changes:   
              ----------
              installed:
                  - Postgres.app
----------
          ID: pg-package-install
    Function: file.append
        Name: /Users/messi/.bash_profile
      Result: True
     Comment: Appended 1 lines
     Started: 10:30:54.536223
    Duration: 20.205 ms
     Changes:   
              ----------
              diff:
                  --- 
                  
                  +++ 
                  
                  @@ -26,3 +26,4 @@
                  
                   #### HOSTS #####
                   alias tm='cd && ssh tm'
                   export PATH="/usr/local/sbin:$PATH"
                  +export PATH=$PATH:/Applications/Postgres.app/Contents/Versions/latest/bin
----------
          ID: pg-remove-archive
    Function: file.absent
        Name: /tmp/postgrestmp
      Result: True
     Comment: Removed directory /tmp/postgrestmp
     Started: 10:30:54.556690
    Duration: 2.163 ms
     Changes:   
              ----------
              removed:
                  /tmp/postgrestmp
----------
          ID: postgres_maxfiles_limits_conf
    Function: file.managed
        Name: /Library/LaunchDaemons/limit.maxfiles.plist
      Result: True
     Comment: File /Library/LaunchDaemons/limit.maxfiles.plist is in the correct state
     Started: 10:30:54.558930
    Duration: 13.938 ms
     Changes:   
----------
          ID: postgres-desktop-shortcut-clean
    Function: file.absent
        Name: /Users/messi/Desktop/postgres
      Result: True
     Comment: File /Users/messi/Desktop/postgres is not present
     Started: 10:30:54.572969
    Duration: 0.427 ms
     Changes:   
----------
          ID: postgres-desktop-shortcut-add
    Function: file.managed
        Name: /tmp/mac_shortcut.sh
      Result: True
     Comment: File /tmp/mac_shortcut.sh updated
     Started: 10:30:54.573711
    Duration: 7.17 ms
     Changes:   
              ----------
              diff:
                  New file
              mode:
                  0755
              user:
                  messi
----------
          ID: postgres-desktop-shortcut-add
    Function: cmd.run
        Name: /tmp/mac_shortcut.sh postgresapp
      Result: True
     Comment: Command "/tmp/mac_shortcut.sh postgresapp" run
     Started: 10:30:54.581287
    Duration: 440.299 ms
     Changes:   
              ----------
              pid:
                  5168
              retcode:
                  0
              stderr:
              stdout:
                  alias file Postgres of folder Desktop of folder messi of folder Users of startup disk

Summary for local
-------------
Succeeded: 11 (changed=7)
Failed:     0
-------------
Total states run:     11
Total run time:  248.537 s

```



** HOMEBREW **
```
[ERROR   ] Service homebrew.mxcl.postgresql failed to start
local:
----------
          ID: postgresql-server
    Function: pkg.installed
      Result: True
     Comment: The following packages were installed/updated: postgresql
     Started: 13:13:12.225375
    Duration: 6148.853 ms
     Changes:   
              ----------
              postgresql:
                  ----------
                  new:
                      10.1
                  old:
----------
          ID: postgresql-server
    Function: file.managed
        Name: /Library/LaunchAgents/homebrew.mxcl.postgresql.plist
      Result: True
     Comment: File /Library/LaunchAgents/homebrew.mxcl.postgresql.plist updated
     Started: 13:13:13.378074
    Duration: 13.146 ms
     Changes:   
              ----------
              diff:
                  New file
              mode:
                  0644
----------
          ID: postgresql-cluster-prepared
    Function: cmd.run
        Name: initdb -D /Users/messi/Library/AppSupport/postgres_homebrew
      Result: True
     Comment: Command "initdb -D /Users/messi/Library/AppSupport/postgres_homebrew" run
     Started: 13:13:13.392806
    Duration: 801.939 ms
     Changes:   
              ----------
              pid:
                  30633
              retcode:
                  0
              stderr:
                  
                  WARNING: enabling "trust" authentication for local connections
                  You can change this by editing pg_hba.conf or using the option -A, or
                  --auth-local and --auth-host, the next time you run initdb.
              stdout:
                  The files belonging to this database system will be owned by user "messi".
                  This user must also own the server process.
                  
                  The database cluster will be initialized with locale "C".
                  The default database encoding has accordingly been set to "SQL_ASCII".
                  The default text search configuration will be set to "english".
                  
                  Data page checksums are disabled.
                  
                  creating directory /Users/messi/Library/AppSupport/postgres_homebrew ... ok
                  creating subdirectories ... ok
                  selecting default max_connections ... 100
                  selecting default shared_buffers ... 128MB
                  selecting dynamic shared memory implementation ... posix
                  creating configuration files ... ok
                  running bootstrap script ... ok
                  performing post-bootstrap initialization ... ok
                  syncing data to disk ... ok
                  
                  Success. You can now start the database server using:
                  
                      pg_ctl -D /Users/messi/Library/AppSupport/postgres_homebrew -l logfile start
----------
          ID: postgresql-config-dir
    Function: file.directory
        Name: /Users/messi/Library/AppSupport/postgres_homebrew
      Result: True
     Comment: Directory /Users/messi/Library/AppSupport/postgres_homebrew updated
     Started: 13:13:19.195268
    Duration: 219.31 ms
     Changes:   
              ----------
              mode:
                  0775
----------
          ID: postgresql-conf
    Function: file.blockreplace
        Name: /Users/messi/Library/AppSupport/postgres_homebrew/postgresql.conf
      Result: True
     Comment: Changes were made
     Started: 13:13:19.414895
    Duration: 4.529 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -656,3 +656,6 @@
                   #------------------------------------------------------------------------------
                   
                   # Add settings for extensions here
                  +# Managed by SaltStack: listen_addresses: please do not edit
                  +listen_addresses = '*'  # listen on all interfaces
                  +# Managed by SaltStack: end of salt managed zone --
----------
          ID: postgresql-pg_hba
    Function: file.managed
        Name: /Users/messi/Library/AppSupport/postgres_homebrew/pg_hba.conf
      Result: True
     Comment: File /Users/messi/Library/AppSupport/postgres_homebrew/pg_hba.conf updated
     Started: 13:13:19.419582
    Duration: 3792.969 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -1,93 +1,23 @@
                  +######################################################################
                  +# ATTENTION! Managed by SaltStack.                                   #
                  +# DO NOT EDIT THIS FILE BY HAND -- YOUR CHANGES WILL BE OVERWRITTEN! #
                  +######################################################################
                  +#
                   # PostgreSQL Client Authentication Configuration File
                   # ===================================================
                   #
                   # Refer to the "Client Authentication" section in the PostgreSQL
                  -# documentation for a complete description of this file.  A short
                  -# synopsis follows.
                  -#
                  -# This file controls: which hosts are allowed to connect, how clients
                  -# are authenticated, which PostgreSQL user names they can use, which
                  -# databases they can access.  Records take one of these forms:
                  -#
                  -# local      DATABASE  USER  METHOD  [OPTIONS]
                  -# host       DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
                  -# hostssl    DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
                  -# hostnossl  DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
                  -#
                  -# (The uppercase items must be replaced by actual values.)
                  -#
                  -# The first field is the connection type: "local" is a Unix-domain
                  -# socket, "host" is either a plain or SSL-encrypted TCP/IP socket,
                  -# "hostssl" is an SSL-encrypted TCP/IP socket, and "hostnossl" is a
                  -# plain TCP/IP socket.
                  -#
                  -# DATABASE can be "all", "sameuser", "samerole", "replication", a
                  -# database name, or a comma-separated list thereof. The "all"
                  -# keyword does not match "replication". Access to replication
                  -# must be enabled in a separate record (see example below).
                  -#
                  -# USER can be "all", a user name, a group name prefixed with "+", or a
                  -# comma-separated list thereof.  In both the DATABASE and USER fields
                  -# you can also write a file name prefixed with "@" to include names
                  -# from a separate file.
                  -#
                  -# ADDRESS specifies the set of hosts the record matches.  It can be a
                  -# host name, or it is made up of an IP address and a CIDR mask that is
                  -# an integer (between 0 and 32 (IPv4) or 128 (IPv6) inclusive) that
                  -# specifies the number of significant bits in the mask.  A host name
                  -# that starts with a dot (.) matches a suffix of the actual host name.
                  -# Alternatively, you can write an IP address and netmask in separate
                  -# columns to specify the set of hosts.  Instead of a CIDR-address, you
                  -# can write "samehost" to match any of the server's own IP addresses,
                  -# or "samenet" to match any address in any subnet that the server is
                  -# directly connected to.
                  -#
                  -# METHOD can be "trust", "reject", "md5", "password", "scram-sha-256",
                  -# "gss", "sspi", "ident", "peer", "pam", "ldap", "radius" or "cert".
                  -# Note that "password" sends passwords in clear text; "md5" or
                  -# "scram-sha-256" are preferred since they send encrypted passwords.
                  -#
                  -# OPTIONS are a set of options for the authentication in the format
                  -# NAME=VALUE.  The available options depend on the different
                  -# authentication methods -- refer to the "Client Authentication"
                  -# section in the documentation for a list of which options are
                  -# available for which authentication methods.
                  -#
                  -# Database and user names containing spaces, commas, quotes and other
                  -# special characters must be quoted.  Quoting one of the keywords
                  -# "all", "sameuser", "samerole" or "replication" makes the name lose
                  -# its special character, and just match a database or username with
                  -# that name.
                  -#
                  -# This file is read on server startup and when the server receives a
                  -# SIGHUP signal.  If you edit the file on a running system, you have to
                  -# SIGHUP the server for the changes to take effect, run "pg_ctl reload",
                  -# or execute "SELECT pg_reload_conf()".
                  -#
                  -# Put your actual configuration here
                  -# ----------------------------------
                  -#
                  -# If you want to allow non-local connections, you need to add more
                  -# "host" records.  In that case you will also need to make PostgreSQL
                  -# listen on a non-local interface via the listen_addresses
                  -# configuration parameter, or via the -i or -h command line switches.
                  +# documentation for a complete description of this file.
                   
                  -# CAUTION: Configuring the system for local "trust" authentication
                  -# allows any local user to connect as any PostgreSQL user, including
                  -# the database superuser.  If you do not trust all your local users,
                  -# use another authentication method.
                  +# DO NOT DISABLE!
                  +# If you change this first entry you will need to make sure that the
                  +# database superuser can access the database using some other method.
                  +# Noninteractive access to all databases is required during automatic
                  +# maintenance (custom daily cronjobs, replication, and similar tasks).
                   
                  +# Database administrative login by Unix domain socket
                  +local   all             postgres                                peer
                   
                   # TYPE  DATABASE        USER            ADDRESS                 METHOD
                  -
                  -# "local" is for Unix domain socket connections only
                  -local   all             all                                     trust
                  -# IPv4 local connections:
                  -host    all             all             127.0.0.1/32            trust
                  -# IPv6 local connections:
                  -host    all             all             ::1/128                 trust
                  -# Allow replication connections from localhost, by a user with the
                  -# replication privilege.
                  -local   replication     all                                     trust
                  -host    replication     all             127.0.0.1/32            trust
                  -host    replication     all             ::1/128                 trust
                  +local   db1             localUser                               md5
                  +host    db2             remoteUser      192.168.33.0/24         md5
----------
          ID: postgresql-tablespace-dir-my_space
    Function: file.directory
        Name: /srv/my_tablespace
      Result: True
     Comment: Directory /srv/my_tablespace is in the correct state
              Directory /srv/my_tablespace updated
     Started: 13:13:23.212795
    Duration: 47.959 ms
     Changes:   
----------
          ID: postgresql-running
    Function: service.running
        Name: homebrew.mxcl.postgresql
      Result: True
     Comment: Service started
     Started: 13:13:23.296112
    Duration: 17.441 ms
     Changes:   
              ----------
              homebrew.mxcl.postgresql:
                  True
----------
          ID: postgresql-client-libs
    Function: pkg.installed
      Result: True
     Comment: No packages to install provided
     Started: 13:13:23.313812
    Duration: 0.447 ms
     Changes:   
----------
          ID: postgres_maxfiles_limits_conf
    Function: file.managed
        Name: /Library/LaunchDaemons/limit.maxfiles.plist
      Result: True
     Comment: File /Library/LaunchDaemons/limit.maxfiles.plist is in the correct state
     Started: 13:13:23.314350
    Duration: 2.801 ms
     Changes:   

Summary for local
-------------
Succeeded: 10 (changed=7)
Failed:     0
-------------
Total states run:     10
Total run time:   11.049 s
```