### PR TITLE
Avoid corrupted upstream install on Debian's

### DIFF
--- a/postgres/osfamilymap.yaml
+++ b/postgres/osfamilymap.yaml
@@ -16,7 +16,11 @@ Debian:
     key_url: 'https://www.postgresql.org/media/keys/ACCC4CF8.asc'
     file: /etc/apt/sources.list.d/pgdg.list
   pkg_repo_keyid: ACCC4CF8
+    {% if repo.use_upstream_repo == true %}
+  pkg_dev: ''
+    {% else %}
   pkg_dev: postgresql-server-dev-all
+    {% endif %}
 
 FreeBSD:
   user: pgsql


### PR DESCRIPTION
When using **upstream repo** on Debian family, the formula installs both upstream and downstream PG releases to satisfy `postgres-server-dev-all` dependencies. This is unwanted situation.

This PR avoids corrupted upstream PG installation on Debian family.