### PR TITLE
Use osmap for OS handling of fedora repo

### DIFF
--- a/postgres/map.jinja
+++ b/postgres/map.jinja
@@ -1,5 +1,6 @@
 {% import_yaml "postgres/defaults.yaml" as defaults %}
 {% import_yaml "postgres/osfamilymap.yaml" as osfamilymap %}
+{% import_yaml "postgres/osmap.yaml" as osmap %}
 {% import_yaml "postgres/codenamemap.yaml" as oscodenamemap %}
 
 {% set postgres = salt['grains.filter_by'](
@@ -8,9 +9,13 @@
         osfamilymap,
         grain='os_family',
         merge=salt['grains.filter_by'](
-            oscodenamemap,
-            grain='oscodename',
-            merge=salt['pillar.get']('postgres', {}),
+            osmap,
+            grain='os',
+            merge=salt['grains.filter_by'](
+                oscodenamemap,
+                grain='oscodename',
+                merge=salt['pillar.get']('postgres', {}),
+            ),
         ),
     ),
     base='postgres',

--- a/postgres/osfamilymap.yaml
+++ b/postgres/osfamilymap.yaml
@@ -30,11 +30,7 @@ RedHat:
     humanname: PostgreSQL {{ repo.version }} $releasever - $basearch
     gpgcheck: 1
     gpgkey: 'https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-{{ release }}'
-    {% if grains.os == 'Fedora' %}
-    baseurl: 'https://download.postgresql.org/pub/repos/yum/{{ repo.version }}/fedora/fedora-$releasever-$basearch'
-    {% else %}
     baseurl: 'https://download.postgresql.org/pub/repos/yum/{{ repo.version }}/redhat/rhel-$releasever-$basearch'
-    {% endif %}
 
 {% if repo.use_upstream_repo == true %}
   {% set data_dir = '/var/lib/pgsql/' ~ repo.version ~ '/data' %}

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -1,0 +1,7 @@
+{% import_yaml "postgres/repo.yaml" as repo %}
+
+Fedora:
+  pkg_repo:
+    baseurl: 'https://download.postgresql.org/pub/repos/yum/{{ repo.version }}/fedora/fedora-$releasever-$basearch'
+
+# vim: ft=sls


### PR DESCRIPTION
This PR is better implementation of #196 (Fedora repo). The OS specific code for Fedora is moved to osmap.yaml which is cleaner and removes some Jinja code.