### PR TITLE
Allow setting dir mode for conf_dir in pillar

### DIFF
--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -21,6 +21,7 @@ postgres:
     env: []
 
   conf_dir: /var/lib/pgsql/data
+  conf_dir_mode: 0775
   postgresconf: ""
 
   macos:

--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -72,7 +72,7 @@ postgresql-config-dir:
     - name: {{ postgres.conf_dir }}
     - user: {{ postgres.user }}
     - group: {{ postgres.group }}
-    - dir_mode: 775
+    - dir_mode: {{ postgres.conf_dir_mode }}
     - force: True
     - file_mode: 644
     - recurse:


### PR DESCRIPTION
The current mode of 0775 causes start problems:

`FATAL:  data directory "/var/lib/postgresql/9.6/main" has group or world access`