### PR TITLE
use upstream repo for python if configured

### DIFF
--- a/postgres/python.sls
+++ b/postgres/python.sls
@@ -1,5 +1,16 @@
 {% from "postgres/map.jinja" import postgres with context %}
 
+include:
+  - postgres.upstream
+
 postgresql-python:
   pkg.installed:
     - name: {{ postgres.pkg_python}}
+  {% if postgres.fromrepo %}
+    - fromrepo: {{ postgres.fromrepo }}
+  {% endif %}
+  {% if postgres.use_upstream_repo == true %}
+    - refresh: True
+    - require:
+      - pkgrepo: postgresql-repo
+  {% endif %}


### PR DESCRIPTION
For some reason `python.sls` was missing upstream repo support. PR to fix that.