### PR TITLE
Fix compatibility with Salt 2018.3.0

### DIFF
--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -114,7 +114,7 @@ postgresql-pg_hba:
     - source: {{ postgres['pg_hba.conf'] }}
     - template: jinja
     - defaults:
-        acls: {{ postgres.acls }}
+        acls: {{ postgres.acls|yaml() }}
   {%- if postgres.config_backup %}
     # Create the empty file before managing to overcome the limitation of check_cmd
     - onlyif: test -f {{ pg_hba_path }} || touch {{ pg_hba_path }}
@@ -141,7 +141,7 @@ postgresql-pg_ident:
     - source: {{ postgres['pg_ident.conf'] }}
     - template: jinja
     - defaults:
-        mappings: {{ postgres.identity_map }}
+        mappings: {{ postgres.identity_map|yaml() }}
   {%- if postgres.config_backup %}
     # Create the empty file before managing to overcome the limitation of check_cmd
     - onlyif: test -f {{ pg_ident_path }} || touch {{ pg_ident_path }}


### PR DESCRIPTION
This PR makes sure that data structures like nested lists (or dictionaries) are properly translated to valid YAML syntax. It also makes the formula work with latest stable version of Salt: 2018.3.0.