### PR TITLE
Introduce fromrepo support.

### DIFF
--- a/postgres/codenamemap.yaml
+++ b/postgres/codenamemap.yaml
@@ -18,12 +18,18 @@
   {# use upstream version if configured #}
   {% if repo.use_upstream_repo == true %}
     {% set version = repo.version %}
+    {% set fromrepo = repo.fromrepo or name + '-pgdg' %}
+    {% set pkg_dev = '' %}
+  {% else %}
+    {% set fromrepo = name %}
+    {% set pkg_dev = 'postgresql-server-dev-all' %}
   {% endif %}
 
 {{ codename|default(name, true) }}:
   # PostgreSQL packages are mostly downloaded from `main` repo component
+  fromrepo: {{ fromrepo }}
   pkg_repo:
-    name: 'deb http://apt.postgresql.org/pub/repos/apt {{ name }}-pgdg main {{ repo.version }}'
+    name: 'deb http://apt.postgresql.org/pub/repos/apt {{ name }}-pgdg main {{ version }}'
   pkg: postgresql-{{ version }}
   pkg_client: postgresql-client-{{ version }}
   conf_dir: /etc/postgresql/{{ version }}/main
@@ -55,6 +61,7 @@
 
 {{ codename|default(name, true) }}:
   # PostgreSQL packages are mostly downloaded from `main` repo component
+  fromrepo: {{ name }}
   pkg_repo:
     baseurl: 'https://download.postgresql.org/pub/repos/yum/{{ version }}/fedora/fedora-$releasever-$basearch'
 

--- a/postgres/codenamemap.yaml
+++ b/postgres/codenamemap.yaml
@@ -19,10 +19,8 @@
   {% if repo.use_upstream_repo == true %}
     {% set version = repo.version %}
     {% set fromrepo = repo.fromrepo or name + '-pgdg' %}
-    {% set pkg_dev = '' %}
   {% else %}
     {% set fromrepo = name %}
-    {% set pkg_dev = 'postgresql-server-dev-all' %}
   {% endif %}
 
 {{ codename|default(name, true) }}:

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -58,8 +58,6 @@ postgres:
   bake_image: False
 
   fromrepo:
-  pkg_repo:
-    name: []
 
   users: {}
   tablespaces: {}

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -57,6 +57,10 @@ postgres:
 
   bake_image: False
 
+  fromrepo:
+  pkg_repo:
+    name: []
+
   users: {}
   tablespaces: {}
   databases: {}

--- a/postgres/dev.sls
+++ b/postgres/dev.sls
@@ -6,12 +6,18 @@
 install-postgres-dev-package:
   pkg.installed:
     - name: {{ postgres.pkg_dev }}
+    {% if postgres.fromrepo %}
+    - fromrepo: {{ postgres.fromrepo }}
+    {% endif %}
   {% endif %}
 
   {% if postgres.pkg_libpq_dev %}
 install-postgres-libpq-dev:
   pkg.installed:
     - name: {{ postgres.pkg_libpq_dev }}
+    {% if postgres.fromrepo %}
+    - fromrepo: {{ postgres.fromrepo }}
+    {% endif %}
   {% endif %}
 
 {% endif %}

--- a/postgres/osfamilymap.yaml
+++ b/postgres/osfamilymap.yaml
@@ -39,6 +39,7 @@ RedHat:
 {% if repo.use_upstream_repo == true %}
   {% set data_dir = '/var/lib/pgsql/' ~ repo.version ~ '/data' %}
 
+  fromrepo: pgdg{{ release }}
   pkg: postgresql{{ release }}-server
   pkg_client: postgresql{{ release }}
   pkg_libs: postgresql{{ release }}-libs
@@ -112,6 +113,7 @@ Suse:
 {% if repo.use_upstream_repo == true %}
   {% set lib_dir = '/var/lib/pgsql/' ~ repo.version ~ '/data' %}
 
+  fromrepo: pgdg-sles-{{ release }}
   pkg: postgresql{{ release }}-server
   pkg_client: postgresql{{ release }}
   pkg_dev: postgresql{{ release }}-devel

--- a/postgres/python.sls
+++ b/postgres/python.sls
@@ -3,3 +3,6 @@
 postgresql-python:
   pkg.installed:
     - name: {{ postgres.pkg_python}}
+  {% if postgres.fromrepo %}
+    - fromrepo: {{ postgres.fromrepo }}
+  {% endif %}

--- a/postgres/repo.yaml
+++ b/postgres/repo.yaml
@@ -3,10 +3,9 @@
 
 {% import_yaml "postgres/defaults.yaml" as defaults %}
 
-use_upstream_repo: {{ salt['pillar.get']('postgres:use_upstream_repo',
-                                         defaults.postgres.use_upstream_repo) }}
-version: {{ salt['pillar.get']('postgres:version',
-                               defaults.postgres.version) }}
+use_upstream_repo: {{ salt['pillar.get']('postgres:use_upstream_repo', defaults.postgres.use_upstream_repo) }}
+version: {{ salt['pillar.get']('postgres:version', defaults.postgres.version) }}
+fromrepo: {{ salt['pillar.get']('postgres:fromrepo', defaults.postgres.fromrepo) }}
 
 #Early lookup for system user on MacOS
 {% if grains.os == 'MacOS' %}

--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -23,6 +23,9 @@ postgresql-server:
     - require:
       - pkgrepo: postgresql-repo
 {%- endif %}
+  {%- if postgres.fromrepo %}
+    - fromrepo: {{ postgres.fromrepo }}
+  {%- endif %}
   {%- if grains.os == 'MacOS' %}
      #Register as Launchd LaunchAgent for system users
     - require_in:


### PR DESCRIPTION
This PR introduces `fromrepo` support (replaces #185 and resolves #133).  Testing was done on Ubuntu/Centos/Fedora.   Comments welcomed.
