### PR TITLE
Tidyup codenamemap.yaml for Fedora

### DIFF
--- a/postgres/codenamemap.yaml
+++ b/postgres/codenamemap.yaml
@@ -2,18 +2,13 @@
 
 {% import_yaml "postgres/repo.yaml" as repo %}
 
-{% macro debian_codename(name, version, codename=none) %}
-  {#
-  Generate lookup dictionary map for Debian and derivative distributions
-
-    name:
-      distro codename
-    version:
-      PostgreSQL release version
-    codename:
-      optional grain value if `name` does not match the one returned by
-      `oscodename` grain
+  {# Generate lookup dictionary map for OS and derivative distributions
+    name: distro codename
+    version: PostgreSQL release version
+    codename: optional grain value if `name` does not match the one returned by `oscodename` grain
   #}
+
+{% macro debian_codename(name, version, codename=none) %}
 
   {# use upstream version if configured #}
   {% if repo.use_upstream_repo == true %}
@@ -40,21 +35,13 @@
 
 
 {% macro fedora_codename(name, version, codename=none) %}
-  {#
-  Generate lookup dictionary map for Fedora distributions
-
-    name:
-      distro codename
-    version:
-      PostgreSQL release version
-    codename:
-      optional grain value if `name` does not match the one returned by
-      `oscodename` grain
-  #}
 
   {# use upstream version if configured #}
   {% if repo.use_upstream_repo == true %}
+    {% set fromrepo = repo.fromrepo or name + '-pgdg' %}
     {% set version = repo.version %}
+  {% else %}
+    {% set fromrepo = name %}
   {% endif %}
 
 {{ codename|default(name, true) }}:


### PR DESCRIPTION
This PR is small tidyup following PR #209 (add fromrepo support).

1) The Fedora section is missing `{% set fromrepo ....}` statements - my mistake.
2) Repeating `{% if repo.use_upstream_repo == true %}` block is unnecessary, use one only.