### PR TITLE
Prevent default `fromrepo` being evaluated as string 'None'

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -4,6 +4,9 @@ postgres:
   use_upstream_repo: False
   # Version to install from upstream repository (if upstream_repo: True)
   version: '9.6'
+  # If automatic package installation fails, use `fromrepo` to specify the
+  # upstream repo to install packages from [#133, #185] (if upstream_repo: True)
+  fromrepo: 'jessie-pgdg'
 
   ### MACOS
   # Set to 'postgresapp' OR 'homebrew' for MacOS

--- a/postgres/codenamemap.yaml
+++ b/postgres/codenamemap.yaml
@@ -13,7 +13,7 @@
   {# use upstream version if configured #}
   {% if repo.use_upstream_repo == true %}
     {% set version = repo.version %}
-    {% set fromrepo = repo.fromrepo or name + '-pgdg' %}
+    {% set fromrepo = repo.fromrepo|default(name ~ '-pgdg', true) %}
   {% else %}
     {% set fromrepo = name %}
   {% endif %}
@@ -38,7 +38,7 @@
 
   {# use upstream version if configured #}
   {% if repo.use_upstream_repo == true %}
-    {% set fromrepo = repo.fromrepo or name + '-pgdg' %}
+    {% set fromrepo = repo.fromrepo|default(name ~ '-pgdg', true) %}
     {% set version = repo.version %}
   {% else %}
     {% set fromrepo = name %}

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -32,8 +32,8 @@ postgres:
       url: https://github.com/PostgresApp/PostgresApp/releases/download/v2.1.1/Postgres-2.1.1.dmg
       sum: sha256=ac0656b522a58fd337931313f09509c09610c4a6078fe0b8e469e69af1e1750b
     homebrew:
-      url:
-      sum:
+      url: ''
+      sum: ''
     dl:
       opts: -s -L
       interval: 60
@@ -67,4 +67,4 @@ postgres:
 
   linux:
     #Alternatives system are disabled by a 'altpriority=0' pillar.
-    altpriority:
+    altpriority: 0

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -57,7 +57,7 @@ postgres:
 
   bake_image: False
 
-  fromrepo:
+  fromrepo: ''
 
   users: {}
   tablespaces: {}


### PR DESCRIPTION
#### Discussion

@noelmcloughlin Thanks for #209; this follows-on from that.

I've been using this formula for some time with `use_upstream_repo: True`.  Didn't have a value for `fromrepo` in the pillar when running this formula for a new minion.  Encountered an error:

```saltstack
          ID: postgresql-server
    Function: pkg.installed
      Result: False
     Comment: Problem encountered installing package(s). Additional info follows:
              
              errors:
                  - Running scope as unit: run-r446ecf8982944cd4a4caa7bf54ad2e02.scope
                    E: The value 'None' is invalid for APT::Default-Release as such a release is not available in the sources
```

Initially tracked back to:

https://github.com/saltstack-formulas/postgres-formula/blob/3d8d8486ed88caa6c93d7a86932daf42fc3977ab/postgres/codenamemap.yaml#L16

* This was being evaluated as `'None'`

Then tracked back to:

https://github.com/saltstack-formulas/postgres-formula/blob/3d8d8486ed88caa6c93d7a86932daf42fc3977ab/postgres/defaults.yaml#L60

* Used debug output of `defaults.postgres` to establish that the bare `fromrepo:` above results in `{..., 'fromrepo': 'None', ...}`

The proposed change in this PR allows `fromrepo` to be evaluated as intended.

---

#### Further potential issues

When collecting the debug output of `defaults.postgres`, the `'None'` strings present correlate with all of the bare defaults:

```python
{
    ...

        'homebrew': {
            'url', 'None',
            'sum': 'None'
        },

    ...

    'fromrepo': 'None',

    ...

    'linux': {
        'altpriority': 'None'
    }
}
```

Appears that it would be appropriate to set default values for these as well, unless there is a specific reason for using `'None'` as a string.

---

#### Consideration: Add `fromrepo` to `pillar.example`

It's probably useful to have `fromrepo` mentioned in `pillar.example`.  Finding an appropriate example value may be difficult.  Was thinking about adding `fromrepo: 'bionic-pgdg'` to this PR but that is Ubuntu-specific.