### PR TITLE
Allow `port` to be configurable

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -32,6 +32,10 @@ postgres:
     hard: 64000
 
   # POSTGRES
+  # Non-standard port to use for the cluster
+  # Only set if port `5432` is not appropriate
+  port: 5433
+
   # Append the lines under this item to your postgresql.conf file.
   # Pay attention to indent exactly with 4 spaces for all lines.
   postgresconf: |

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -3,6 +3,7 @@
 postgres:
   use_upstream_repo: True
   version: '9.5'
+  default_port: 5432
   pkg: postgresql
   pkgs_extra: []
   pkg_client: postgresql-client

--- a/postgres/macros.jinja
+++ b/postgres/macros.jinja
@@ -23,6 +23,7 @@
 {{ state }}-{{ name }}:
   {{ state }}.{{ ensure|default('present') }}:
     {{- format_kwargs(kwarg) }}
+    - db_port: {{ postgres.port|default(postgres.default_port) }}
     - onchanges:
       - test: postgres-reload-modules
 

--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -192,3 +192,24 @@ postgresql-running:
       - file: postgresql-pg_ident
 
 {%- endif %}
+
+{%- if postgres.port|default(false) %}
+
+postgresql-port:
+  file.replace:
+    - name: {{ postgres.conf_dir }}/postgresql.conf
+    - pattern: ^#*\s*(port)\s*=\s*\d{4,5}(.*)$
+    - repl: \1 = {{ postgres.port }}\2
+    - flags: 8  # ['MULTILINE']
+    - show_changes: True
+    - append_if_not_found: True
+    - backup: {{ postgres.config_backup|default(false, true) }}
+    - require:
+      - file: postgresql-config-dir
+    - watch_in:
+       - service: postgresql-port
+
+  service.running:
+    - name: {{ postgres.service }}
+
+{%- endif %}


### PR DESCRIPTION
#### References

1. #174 
1. https://github.com/saltstack-formulas/postgres-formula/issues/43#issuecomment-302681240

#### Discussion

I've been using this formula for a while now and like the comment linked above, I've been able to use `db_port` to adapt to clusters not using the default port of `5432`.

The implementation does not affect existing configurations.  The non-standard `port` would have to be explicitly provided in the pillar.

Changing the port requires a service restart, so the existing service reload state doesn't work -- hence using `service.running` again.  More could be done to check the various situations but I preferred simplicity to efficiency, at least when introducing this functionality.

I envisage that this is a useful first step towards adding support for multiple clusters / versions (i.e. #174).

#### Concerns

The will probably necessitate modification of:

https://github.com/saltstack-formulas/postgres-formula/blob/800259dffe5b89f11d4198d2bd5df163bad5d9aa/test/integration/default/serverspec/postgres_spec.rb#L10

#### Regex description

```regex
- `^`        Line start
- `#*\s*`    Find line even if commented out
- `(port)`   'port' -- capture as backreference `\1`
- `\s*=\s*`  Equals sign, whether or not surrounded by whitespace
- `\d{4,5}`  Existing port value, expected at 4/5 digits
- `(.*)`     Remainder (i.e. comment) -- capture as backreference `\2`
- `$`        Line end
```