### PR TITLE
Fix dev package os dependencies

### DIFF
--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -7,6 +7,7 @@ postgres:
   pkgs_extra: []
   pkg_client: postgresql-client
   pkg_dev: postgresql-devel
+  pkg_dev_deps: []
   pkg_libpq_dev: libpq-dev
   pkg_libs: postgresql-libs
   pkg_python: python-psycopg2

--- a/postgres/dev.sls
+++ b/postgres/dev.sls
@@ -1,26 +1,18 @@
 {% from tpldir + "/map.jinja" import postgres with context %}
 
 {% if grains.os not in ('Windows', 'MacOS',) %}
+  {%- set pkgs = [postgres.pkg_dev, postgres.pkg_libpq_dev] + postgres.pkg_dev_deps %}
 
-  {% if postgres.pkg_dev %}
-install-postgres-dev-package:
+  {% if pkgs %}
+install-postgres-dev-packages:
   pkg.installed:
-    - name: {{ postgres.pkg_dev }}
+    - pkgs: {{ pkgs }}
     {% if postgres.fromrepo %}
     - fromrepo: {{ postgres.fromrepo }}
     {% endif %}
   {% endif %}
 
-  {% if postgres.pkg_libpq_dev %}
-install-postgres-libpq-dev:
-  pkg.installed:
-    - name: {{ postgres.pkg_libpq_dev }}
-    {% if postgres.fromrepo %}
-    - fromrepo: {{ postgres.fromrepo }}
-    {% endif %}
-  {% endif %}
-
-# Alternatives system. Make devclient binaries available in $PATH
+  # Alternatives system. Make devclient binaries available in $PATH
   {%- if 'bin_dir' in postgres and postgres.linux.altpriority %}
     {%- for bin in postgres.dev_bins %}
       {%- set path = salt['file.join'](postgres.bin_dir, bin) %}

--- a/postgres/osfamilymap.yaml
+++ b/postgres/osfamilymap.yaml
@@ -101,6 +101,11 @@ RedHat:
 
 {% endif %}
   pkg_libpq_dev: libpqxx-devel
+  pkg_dev_deps:
+    - perl-Time-HiRes
+    - libicu-devel
+    - perl-IPC-Run
+    - perl-Test-Simple
 
 Suse:
   pkg_repo:


### PR DESCRIPTION
This PR resolves #195.   Tested on Centos7

A separate `pkg.installed` state is needed because `fromrepo` does not apply to this state.
```
 ID: install-postgres-dev-osdependencies
    Function: pkg.installed
      Result: True
     Comment: All specified packages are already installed
     Started: 16:25:56.087576
    Duration: 1405.037 ms
     Changes:   
----------
          ID: install-postgres-dev-package
    Function: pkg.installed
        Name: postgresql95-devel
      Result: True
     Comment: All specified packages are already installed
     Started: 16:25:57.493600
    Duration: 36.49 ms
     Changes:   
----------
          ID: install-postgres-libpq-dev
    Function: pkg.installed
        Name: libpqxx-devel
      Result: True
     Comment: All specified packages are already installed
     Started: 16:25:57.530417
    Duration: 36.693 ms
     Changes:   
----------
          ID: postgresql-ecg-altinstall
    Function: alternatives.install
        Name: ecg
      Result: True
     Comment: onlyif condition is false
     Started: 16:25:57.568191
    Duration: 1078.137 ms
     Changes:   
```