### PR TITLE
Enable replication connections by default in `pg_hba.conf`

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -3,7 +3,7 @@ postgres:
   # Set True to configure upstream postgresql.org repository for YUM/APT/ZYPP
   use_upstream_repo: False
   # Version to install from upstream repository (if upstream_repo: True)
-  version: '9.6'
+  version: '10'
   # If automatic package installation fails, use `fromrepo` to specify the
   # upstream repo to install packages from [#133, #185] (if upstream_repo: True)
   fromrepo: 'jessie-pgdg'

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -47,6 +47,11 @@ postgres:
     - ['host', 'all', 'all', '127.0.0.1/32', 'md5']
     # IPv6 local connections:
     - ['host', 'all', 'all', '::1/128', 'md5']
+    # Allow replication connections from localhost, by a user with the
+    # replication privilege.
+    - ['local', 'replication', 'all', 'peer']
+    - ['host', 'replication', 'all', '127.0.0.1/32', 'md5']
+    - ['host', 'replication', 'all', '::1/128', 'md5']
 
   pg_ident.conf: salt://postgres/templates/pg_ident.conf.j2
   identity_map: []

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -2,7 +2,7 @@
 
 postgres:
   use_upstream_repo: True
-  version: '9.5'
+  version: '10'
   pkg: postgresql
   pkgs_extra: []
   pkg_client: postgresql-client


### PR DESCRIPTION
Upstream commit:

- postgres/postgres@be37c21
- 9 Mar 2017
- master REL_11_BETA1 REL_10_4 ... REL_10_BETA1

When installing version `10`, default `pg_hba.conf` additionally contains:

```conf
# Allow replication connections from localhost, by a user with the
# replication privilege.
local   replication     all                                     peer
host    replication     all             127.0.0.1/32            md5
host    replication     all             ::1/128                 md5
```