### PR TITLE
Client should not install dev libs by default

### DIFF
--- a/postgres/client/init.sls
+++ b/postgres/client/init.sls
@@ -1,7 +1,7 @@
 {%- from salt.file.dirname(tpldir) ~ "/map.jinja" import postgres with context -%}
 
 {%- set pkgs = [] %}
-{%- for pkg in (postgres.pkg_client, postgres.pkg_libpq_dev) %}
+{%- for pkg in (postgres.pkg_client,) %}
   {%- if pkg %}
     {%- do pkgs.append(pkg) %}
   {%- endif %}


### PR DESCRIPTION
Client states should not install development libraries by default (ex. libpqxx-devel)