### PR TITLE
Use upstream instructions for Apt `pkg_repo` (remove unnecessary `version`)

### DIFF
--- a/postgres/codenamemap.yaml
+++ b/postgres/codenamemap.yaml
@@ -22,7 +22,7 @@
   # PostgreSQL packages are mostly downloaded from `main` repo component
   fromrepo: {{ fromrepo }}
   pkg_repo:
-    name: 'deb http://apt.postgresql.org/pub/repos/apt {{ name }}-pgdg main {{ version }}'
+    name: 'deb http://apt.postgresql.org/pub/repos/apt/ {{ name }}-pgdg main'
   pkg: postgresql-{{ version }}
   pkg_client: postgresql-client-{{ version }}
   conf_dir: /etc/postgresql/{{ version }}/main


### PR DESCRIPTION
[Upstream instructions](https://www.postgresql.org/download/linux/ubuntu/):

> Create the file `/etc/apt/sources.list.d/pgdg.list` and add a line for the repository
> ```
> deb http://apt.postgresql.org/pub/repos/apt/ YOUR_UBUNTU_VERSION_HERE-pgdg main
> ```

Not an issue for standard use but does cause unnecessary changes when adapting this formula to support multiple versions/clusters.