### PR TITLE
Allow conf/data directory separation

### DIFF
--- a/postgres/codenamemap.yaml
+++ b/postgres/codenamemap.yaml
@@ -10,25 +10,26 @@
 
 {% macro debian_codename(name, version, codename=none) %}
 
-  {# use upstream version if configured #}
   {% if repo.use_upstream_repo == true %}
     {% set version = repo.version %}
     {% set fromrepo = repo.fromrepo|default(name ~ '-pgdg', true) %}
   {% else %}
     {% set fromrepo = name %}
   {% endif %}
+  {% set conf_dir = '/etc/postgresql/' ~ version ~ '/main' %}
+  {% set data_dir = '/var/lib/postgresql/' ~ version ~ '/main' %}
 
 {{ codename|default(name, true) }}:
   # PostgreSQL packages are mostly downloaded from `main` repo component
+  conf_dir: {{ conf_dir }}
+  data_dir: {{ data_dir }}
   fromrepo: {{ fromrepo }}
   pkg_repo:
     name: 'deb http://apt.postgresql.org/pub/repos/apt/ {{ name }}-pgdg main'
   pkg: postgresql-{{ version }}
   pkg_client: postgresql-client-{{ version }}
-  conf_dir: /etc/postgresql/{{ version }}/main
   prepare_cluster:
-    command: pg_createcluster {{ version }} main
-    test: test -f /var/lib/postgresql/{{ version }}/main/PG_VERSION && test -f /etc/postgresql/{{ version }}/main/postgresql.conf
+    pgcommand: pg_createcluster {{ version }} main -d
     user: root
 
 {% endmacro %}
@@ -38,15 +39,11 @@
 
   {# use upstream version if configured #}
   {% if repo.use_upstream_repo == true %}
-    {% set fromrepo = repo.fromrepo|default(name ~ '-pgdg', true) %}
     {% set version = repo.version %}
-  {% else %}
-    {% set fromrepo = name %}
   {% endif %}
 
 {{ codename|default(name, true) }}:
   # PostgreSQL packages are mostly downloaded from `main` repo component
-  fromrepo: {{ fromrepo }}
   pkg_repo:
     baseurl: 'https://download.postgresql.org/pub/repos/yum/{{ version }}/fedora/fedora-$releasever-$basearch'
 

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -16,12 +16,13 @@ postgres:
   group: postgres
 
   prepare_cluster:
-    command: initdb --pgdata=/var/lib/pgsql/data
-    test: test -f /var/lib/pgsql/data/PG_VERSION
+    pgcommand: initdb -D
+    pgtestfile: PG_VERSION
     user: postgres
     env: []
 
   conf_dir: /var/lib/pgsql/data
+  data_dir: /var/lib/pgsql/data
   conf_dir_mode: '0700'
   postgresconf: ""
 

--- a/postgres/dropped.sls
+++ b/postgres/dropped.sls
@@ -27,4 +27,6 @@ postgresql-removed:
 
 postgres-dir-absent:
   file.absent:
-    - name: {{ postgres.conf_dir }}
+    - names:
+      - {{ postgres.conf_dir }}
+      - {{ postgres.data_dir }}

--- a/postgres/osfamilymap.yaml
+++ b/postgres/osfamilymap.yaml
@@ -4,9 +4,7 @@
 
 Arch:
   conf_dir: /var/lib/postgres/data
-  prepare_cluster:
-    command: initdb -D /var/lib/postgres/data
-    test: test -f /var/lib/postgres/data/PG_VERSION
+  data_dir: /var/lib/postgres/data
   pkg_client: postgresql-libs
   pkg_dev: postgresql
 
@@ -26,6 +24,8 @@ FreeBSD:
   user: pgsql
 
 OpenBSD:
+  conf_dir: /var/postgresql/data
+  data_dir: /var/postgresql/data
   user: _postgresql
 
 RedHat:
@@ -44,12 +44,9 @@ RedHat:
   pkg_client: postgresql{{ release }}
   pkg_libs: postgresql{{ release }}-libs
   pkg_dev: postgresql{{ release }}-devel
-  conf_dir: /var/lib/pgsql/{{ repo.version }}/data
+  conf_dir: {{ data_dir }}
+  data_dir: {{ data_dir }}
   service: postgresql-{{ repo.version }}
-
-  prepare_cluster:
-    command: initdb --pgdata='{{ data_dir }}'
-    test: test -f '{{ data_dir }}/PG_VERSION'
 
   # Alternatives system
   linux:
@@ -118,19 +115,16 @@ Suse:
     gpgautoimport: True
 
 {% if repo.use_upstream_repo == true %}
-  {% set lib_dir = '/var/lib/pgsql/' ~ repo.version ~ '/data' %}
+  {% set data_dir = '/var/lib/pgsql/' ~ repo.version ~ '/data' %}
 
   fromrepo: pgdg-sles-{{ release }}
   pkg: postgresql{{ release }}-server
   pkg_client: postgresql{{ release }}
   pkg_dev: postgresql{{ release }}-devel
   pkg_libs: postgresql{{ release }}-libs
-  conf_dir: {{ lib_dir }}
+  conf_dir: {{ data_dir }}
+  data_dir: {{ data_dir }}
   service: postgresql-{{ repo.version }}
-
-  prepare_cluster:
-    command: /usr/pgsql-{{ repo.version }}/bin/initdb --pgdata='{{ lib_dir }}'
-    test: test -f '{{ lib_dir }}/PG_VERSION'
 
   # Alternatives system
   linux:
@@ -184,9 +178,8 @@ MacOS:
   user: {{ repo.user }}
   group: {{ repo.group }}
   conf_dir: /Users/{{ repo.user }}/Library/AppSupport/postgres_{{ repo.use_upstream_repo }}
+  data_dir: /Users/{{ repo.user }}/Library/AppSupport/postgres_{{ repo.use_upstream_repo }}
   prepare_cluster:
-    command: initdb -D /Users/{{ repo.user }}/Library/AppSupport/postgres_{{ repo.use_upstream_repo }}
-    test: test -f /Users/{{ repo.user }}/Library/AppSupport/postgres_{{ repo.use_upstream_repo }}/PG_VERSION
     user: {{ repo.user }}
     group: {{ repo.group }}
 {%- endif %}

--- a/postgres/server/image.sls
+++ b/postgres/server/image.sls
@@ -12,10 +12,10 @@ include:
 
 postgresql-start:
   cmd.run:
-    - name: pg_ctl -D {{ postgres.conf_dir }} -l logfile start
+    - name: pg_ctl -D {{ postgres.data_dir }} -l logfile start
     - runas: {{ postgres.user }}
     - unless:
-      - ps -p $(head -n 1 {{ postgres.conf_dir }}/postmaster.pid) 2>/dev/null
+      - ps -p $(head -n 1 {{ postgres.data_dir }}/postmaster.pid) 2>/dev/null
     - require:
       - file: postgresql-pg_hba
 


### PR DESCRIPTION
 **This PR adds PostgreSQL support for different `data_dir` and `conf_dir` directories.**    

Supersedes  #187 which listed following advantages-

1. User may want separation of data and configuration.

2. Ubuntu postgresql-server stores config in `/etc`, and data into `/var`.  The `postgres` state fails horribly if `/etc/postgresql/../postgresql.conf` exists, perhaps after `postgres.dropped` runs. 

3. This is **current situation** where `conf_dir` variable exists but not `data_dir`.
```
codenamemap.yaml:  conf_dir: /etc/postgresql/{{ version }}/main
defaults.yaml:  conf_dir: /var/lib/pgsql/data
osmap.yaml:  conf_dir: /var/lib/postgres/data
osmap.yaml:  conf_dir: /var/lib/pgsql/{{ repo.version }}/data
osmap.yaml:  conf_dir: /usr/local/var/postgres
```

4. `postgres` install always fails after 'dropped' (or remove #182) states, because conf_dir remains.

5. If `conf_dir` and `data_dir` have same value, `pg_ctl` throws permissions error.
       `pg_ctl[8774]: FATAL:  data directory "/var/lib/pgsql/data" has group or world access`

Backwards Compatibility: Depreciated `postgres.create_cluster.command` pillar is supported.
