### PR TITLE
Fix `conf_dir` => `data_dir` required for preparing cluster

### DIFF
--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -85,6 +85,8 @@ postgresql-cluster-prepared:
     - require:
       - pkg: postgresql-server
       - file: postgresql-cluster-prepared
+    - watch_in:
+      - module: postgresql-service-restart
 
 postgresql-config-dir:
   file.directory:
@@ -140,14 +142,14 @@ postgresql-conf:
     - watch_in:
       - module: postgresql-service-restart
 
+{%- endif %}
+
 # Restart the service where reloading is not sufficient
-# Currently only when changes are made to `postgresql.conf`
+# Currently when the cluster is created or changes made to `postgresql.conf`
 postgresql-service-restart:
   module.wait:
     - name: service.restart
     - m_name: {{ postgres.service }}
-
-{%- endif %}
 
 {%- set pg_hba_path = salt['file.join'](postgres.conf_dir, 'pg_hba.conf') %}
 


### PR DESCRIPTION
@noelmcloughlin @vutny Thanks for #228, that came at the right time for me as well.  However, this fix is necessary, since the `data_dir` needs to be in place before preparing the cluster.

I've only done basic testing but there also seems to be an issue with starting the server -- otherwise the `postgres.manage` states fail.  I resolved this by adding `--start` to the `pg_createcluster` command.  What are your thoughts about this?