### PR TITLE
Allow configuration of cluster `name`, `locale` & `encoding`

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -26,6 +26,13 @@ postgres:
     - postgresql-contrib
     - postgresql-plpython
 
+  # CLUSTER
+  # The default `encoding` is derived from the `locale` so not recommended
+  # to provide a value for it unless necessary
+  cluster:
+    locale: en_GB.UTF-8
+    # encoding: UTF8
+
   #'Alternatives system' priority incremental. 0 disables feature.
   linux:
     altpriority: 30

--- a/postgres/codenamemap.yaml
+++ b/postgres/codenamemap.yaml
@@ -16,8 +16,9 @@
   {% else %}
     {% set fromrepo = name %}
   {% endif %}
-  {% set conf_dir = '/etc/postgresql/' ~ version ~ '/main' %}
-  {% set data_dir = '/var/lib/postgresql/' ~ version ~ '/main' %}
+  {% set cluster_name = repo.cluster_name %}
+  {% set conf_dir = '/etc/postgresql/{0}/{1}'.format(version, cluster_name) %}
+  {% set data_dir = '/var/lib/postgresql/{0}/{1}'.format(version, cluster_name) %}
 
 {{ codename|default(name, true) }}:
   # PostgreSQL packages are mostly downloaded from `main` repo component
@@ -29,7 +30,7 @@
   pkg: postgresql-{{ version }}
   pkg_client: postgresql-client-{{ version }}
   prepare_cluster:
-    pgcommand: pg_createcluster {{ version }} main -d
+    pgcommand: pg_createcluster {{ version }} {{ cluster_name }} -d
     user: root
 
 {% endmacro %}

--- a/postgres/codenamemap.yaml
+++ b/postgres/codenamemap.yaml
@@ -26,7 +26,7 @@
   data_dir: {{ data_dir }}
   fromrepo: {{ fromrepo }}
   pkg_repo:
-    name: 'deb http://apt.postgresql.org/pub/repos/apt/ {{ name }}-pgdg main'
+    name: 'deb http://apt.postgresql.org/pub/repos/apt {{ name }}-pgdg main'
   pkg: postgresql-{{ version }}
   pkg_client: postgresql-client-{{ version }}
   prepare_cluster:

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -21,6 +21,11 @@ postgres:
     user: postgres
     env: []
 
+  cluster:
+    name: main    # Debian-based only
+    locale: ''    # Defaults to `C`
+    encoding: ''  # Defaults to `SQL_ASCII` if `locale` not provided
+
   conf_dir: /var/lib/pgsql/data
   data_dir: /var/lib/pgsql/data
   conf_dir_mode: '0700'

--- a/postgres/map.jinja
+++ b/postgres/map.jinja
@@ -20,3 +20,13 @@
     ),
     base='postgres',
 ) %}
+
+{# Concatenate the cluster preparation command and then append it to the `postgres` dict #}
+{% set pc_cmd = '{0} {1}'.format(postgres.prepare_cluster.pgcommand, postgres.data_dir) %}
+{% if postgres.cluster.locale %}
+  {% set pc_cmd = '{0} --locale={1}'.format(pc_cmd, postgres.cluster.locale) %}
+{% endif %}
+{% if postgres.cluster.encoding %}
+  {% set pc_cmd = '{0} --encoding={1}'.format(pc_cmd, postgres.cluster.encoding) %}
+{% endif %}
+{% do postgres.update({'prepare_cluster_cmd': pc_cmd}) %}

--- a/postgres/repo.yaml
+++ b/postgres/repo.yaml
@@ -6,6 +6,7 @@
 use_upstream_repo: {{ salt['pillar.get']('postgres:use_upstream_repo', defaults.postgres.use_upstream_repo) }}
 version: {{ salt['pillar.get']('postgres:version', defaults.postgres.version) }}
 fromrepo: {{ salt['pillar.get']('postgres:fromrepo', defaults.postgres.fromrepo) }}
+cluster_name: {{ salt['pillar.get']('postgres:cluster:name', defaults.postgres.cluster.name) }}
 
 #Early lookup for system user on MacOS
 {% if grains.os == 'MacOS' %}

--- a/postgres/repo.yaml
+++ b/postgres/repo.yaml
@@ -10,8 +10,8 @@ cluster_name: {{ salt['pillar.get']('postgres:cluster:name', defaults.postgres.c
 
 #Early lookup for system user on MacOS
 {% if grains.os == 'MacOS' %}
-  {% set sysuser = salt['pillar.get']('postgres.user', salt['cmd.run']("stat -f '%Su' /dev/console")) %}
-  {% set sysgroup = salt['pillar.get']('postgres.group', salt['cmd.run']("stat -f '%Sg' /dev/console")) %}
+  {% set sysuser = salt['pillar.get']('postgres:user', salt['cmd.run']("stat -f '%Su' /dev/console")) %}
+  {% set sysgroup = salt['pillar.get']('postgres:group', salt['cmd.run']("stat -f '%Sg' /dev/console")) %}
 user: {{ sysuser }}
 group: {{ sysgroup }}
 {% endif %}

--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -76,7 +76,14 @@ postgresql-cluster-prepared:
     - name: {{ postgres.prepare_cluster.command }}
     - unless: {{ postgres.prepare_cluster.test }}
  {%- else %}
-    - name: {{ postgres.prepare_cluster.pgcommand }} {{ postgres.data_dir }}
+    {%- set cc_cmd = '{0} {1}'.format(postgres.prepare_cluster.pgcommand, postgres.data_dir) %}
+    {%- if postgres.cluster.locale %}
+      {%- set cc_cmd = '{0} --locale={1}'.format(cc_cmd, postgres.cluster.locale) %}
+    {%- endif %}
+    {%- if postgres.cluster.encoding %}
+      {%- set cc_cmd = '{0} --encoding={1}'.format(cc_cmd, postgres.cluster.encoding) %}
+    {%- endif %}
+    - name: {{ cc_cmd }}
     - unless: test -f {{ postgres.data_dir }}/{{ postgres.prepare_cluster.pgtestfile }}
  {%- endif %}
     - cwd: /

--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -76,14 +76,7 @@ postgresql-cluster-prepared:
     - name: {{ postgres.prepare_cluster.command }}
     - unless: {{ postgres.prepare_cluster.test }}
  {%- else %}
-    {%- set cc_cmd = '{0} {1}'.format(postgres.prepare_cluster.pgcommand, postgres.data_dir) %}
-    {%- if postgres.cluster.locale %}
-      {%- set cc_cmd = '{0} --locale={1}'.format(cc_cmd, postgres.cluster.locale) %}
-    {%- endif %}
-    {%- if postgres.cluster.encoding %}
-      {%- set cc_cmd = '{0} --encoding={1}'.format(cc_cmd, postgres.cluster.encoding) %}
-    {%- endif %}
-    - name: {{ cc_cmd }}
+    - name: {{ postgres.prepare_cluster_cmd }}
     - unless: test -f {{ postgres.data_dir }}/{{ postgres.prepare_cluster.pgtestfile }}
  {%- endif %}
     - cwd: /


### PR DESCRIPTION
#### Commit: Allow configuration of cluster `name`, `locale` & `encoding`

* `name` replaces literal string `main`
* `locale` and `encoding` currently default to `C` and `SQL_ASCII` respectively -- obvious benefit to being able to configure these
    * Using the long form switches for both of these (i.e. `--locale=` & `--encoding=`), which have identical usage in both `initdb` and `pg_createcluster`

---

#### Commit: Remove trailing slash so `pkgrepo.absent` works for Apt

* Trailing slash gets removed by `pkgrepo.managed` so then not found by `pkgrepo.absent`

---

#### Commit: Fix `pillar.get` for `MacOS` user/group early lookup

* Noticed this while working on this PR
* Untested but surely the periods need to be replaced by colons, right?
* If not, will rebase to remove this commit