### PR TITLE
Don't set modes with every run

### DIFF
--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -69,7 +69,6 @@ postgresql-cluster-prepared:
     - recurse:
       - user
       - group
-    - dir_mode: 755
   cmd.run:
  {%- if postgres.prepare_cluster.command is defined %}
       {# support for depreciated 'prepare_cluster.command' pillar #}
@@ -97,9 +96,9 @@ postgresql-config-dir:
     - group: {{ postgres.group }}
     - dir_mode: {{ postgres.conf_dir_mode }}
     - force: True
-    - file_mode: 644
     - recurse:
       - mode
+      - ignore_files
     - makedirs: True
     - require:
       - cmd: postgresql-cluster-prepared


### PR DESCRIPTION
* `postgresql-cluster-prepared`: `dir_mode` is set in `postgresql-config-dir`
* `postgresql-config-dir`: `file_mode` for some files is set to 600, and I think all other files are good with default mode. So don't touch any files, only change dirs.

Otherwise these states are changed back and fort every run:

```
----------
          ID: postgresql-cluster-prepared
    Function: file.directory
        Name: /var/lib/postgresql/10/main
      Result: True
     Comment: Directory /var/lib/postgresql/10/main updated
     Started: 00:46:33.002033
    Duration: 539.572 ms
     Changes:   
              ----------
              mode:
                  0755
----------
          ID: postgresql-config-dir
    Function: file.directory
        Name: /var/lib/postgresql/10/main
      Result: True
     Comment: Directory /var/lib/postgresql/10/main updated
     Started: 00:46:33.565329
    Duration: 235.267 ms
     Changes:   
              ----------
              mode:
                  0644
----------
          ID: postgresql-config-dir
    Function: file.directory
        Name: /etc/postgresql/10/main
      Result: True
     Comment: Directory /etc/postgresql/10/main updated
     Started: 00:46:33.801441
    Duration: 2.057 ms
     Changes:   
              ----------
              mode:
                  0644
----------
          ID: postgresql-pg_hba
    Function: file.managed
        Name: /etc/postgresql/10/main/pg_hba.conf
      Result: True
     Comment: File /etc/postgresql/10/main/pg_hba.conf updated
     Started: 00:46:33.808804
    Duration: 746.758 ms
     Changes:   
              ----------
              mode:
                  0600
----------
          ID: postgresql-pg_ident
    Function: file.managed
        Name: /etc/postgresql/10/main/pg_ident.conf
      Result: True
     Comment: 
     Started: 00:46:34.556873
    Duration: 1.279 ms
     Changes:   
              ----------
              mode:
                  0600
----------
          ID: postgresql-running
    Function: service.running
        Name: postgresql
      Result: True
     Comment: Service reloaded
     Started: 00:46:34.583204
    Duration: 51.512 ms
     Changes:   
              ----------
              postgresql:
                  True
```