### PR TITLE
Enhance remove S/W support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Creates such DB objects as: users, tablespaces, databases, schemas and extension
 See ``pillar.example`` file for details.
 
 ``postgres.python``
--------------------
+----------------------
 
 Installs the PostgreSQL adapter for Python on Linux.
 
@@ -83,11 +83,36 @@ The state relies on the ``postgres:use_upstream_repo`` Pillar value which could 
 The ``postgres:version`` Pillar controls which version of the PostgreSQL packages should be
 installed from the upstream Linux repository. Defaults to ``9.5``.
 
+
+Removal states
+===============
+
+``postgres.dropped``
+--------------------
+
+Meta state to remove Postgres software. By default the release specified, or installed by, the formula is targeted only. To target multiple releases, set pillar ``postgres.removal.multiple_releases: True``.
+
+``postgres.server.remove``
+------------------------
+
+Remove server, lib, and contrib packages. The ``postgres.server.remove`` will retain data by default (no data loss) - set pillar ``postgres.remove.data: True`` to remove data and configuration directories also.
+
+``postgres.client.remove``
+------------------------
+
+Remove client package.
+
+``postgres.dev.remove``
+----------------------
+
+Remove development and python packages.
+
+
 Testing
 =======
-The postgres state was tested on MacOS (El Capitan 10.11.6)
+The ``postgres`` state was tested on MacOS (El Capitan 10.11.6), and ``remove`` states on Ubuntu, Centos, and Fedora.
 
-Testing is done with the ``kitchen-salt``.
+Linux testing is done with the ``kitchen-salt``.
 
 ``kitchen converge``
 --------------------

--- a/pillar.example
+++ b/pillar.example
@@ -184,4 +184,9 @@ postgres:
       maintenance_db: db1
     #postgis: {}
 
+  remove:
+    data: True
+    multiple_releases: True
+    releases: ['9.6', '10',]
+
 # vim: ft=yaml ts=2 sts=2 sw=2 et

--- a/postgres/client/remove.sls
+++ b/postgres/client/remove.sls
@@ -1,0 +1,47 @@
+{%- from "postgres/map.jinja" import postgres with context -%}
+
+#remove release installed by formula
+postgresql-client-removed:
+  pkg.removed:
+    - pkgs:
+      {% if postgres.pkg_client %}
+      - {{ postgres.pkg_client }}
+      {% endif %}
+
+{%- if postgres.remove.multiple_releases %}
+    #search for and cleandown multiple releases
+
+  {% for release in postgres.remove.releases %}
+    {% if 'bin_dir' in postgres %}
+      {%- for bin in postgres.client_bins %}
+        {% set path = '/usr/pgsql-' + release|string + '/bin/' + bin %}
+
+postgresql{{ release }}-client-{{ bin }}-alternative-remove:
+  alternatives.remove:
+    - name: {{ bin }}
+    - path: {{ path }}
+        {% if grains.os in ('Fedora', 'CentOS',) %}
+        {# bypass bug #}
+    - onlyif: alternatives --display {{ bin }}
+        {% else %}
+    - onlyif: test -f {{ path }}
+        {% endif %}
+    - require_in:
+      - pkg: postgresql{{ release }}-client-pkgs-removed
+      {%- endfor %}
+    {%- endif %}
+
+postgresql{{ release }}-client-pkgs-removed:
+  pkg.purged:
+    - pkgs:
+      - postgresql
+      - postgresql-{{ release }}
+      - postgresql-{{ release|replace('.', '') }}
+      - postgresql{{ release }}-common
+      - postgresql{{ release }}-jdbc
+      - postgresql{{ release }}
+      - postgresql{{ release|replace('.', '') }}
+
+  {% endfor %}
+
+{%- endif %}

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -80,3 +80,8 @@ postgres:
   linux:
     #Alternatives system are disabled by a 'altpriority=0' pillar.
     altpriority: 0
+
+  remove:
+    data: False
+    multiple_releases: False
+    releases: ['9.2', '9.3', '9.4', '9.5', '9.6', '10',]

--- a/postgres/dev.sls
+++ b/postgres/dev.sls
@@ -23,7 +23,11 @@ postgresql-{{ bin }}-altinstall:
     - link: {{ salt['file.join']('/usr/bin', bin) }}
     - path: {{ path }}
     - priority: {{ postgres.linux.altpriority }}
+      {% if grains.os in ('Fedora', 'CentOS',) %} {# bypass bug #}
+    - onlyif: alternatives --display {{ bin }}
+      {% else %}
     - onlyif: test -f {{ path }}
+      {% endif %}
 
     {%- endfor %}
   {%- endif %}

--- a/postgres/dev/remove.sls
+++ b/postgres/dev/remove.sls
@@ -1,0 +1,55 @@
+{%- from "postgres/map.jinja" import postgres with context -%}
+
+# remove release installed by formula
+postgresql-devel-removed:
+  pkg.removed:
+    - pkgs:
+      {% if postgres.pkg_dev %}
+      - {{ postgres.pkg_dev }}
+      {% endif %}
+      {% if postgres.pkg_libpq_dev %}
+      - {{ postgres.pkg_libpq_dev }}
+      {% endif %}
+      {% if postgres.pkg_python %}
+      - {{ postgres.pkg_python }}
+      {% endif %}
+
+{%- if postgres.remove.multiple_releases %}
+    #search for and cleandown multiple releases
+
+  {% for release in postgres.remove.releases %}
+    {% if 'bin_dir' in postgres %}
+      {%- for bin in postgres.dev_bins %}
+        {% set path = '/usr/pgsql-' + release|string + '/bin/' + bin %}
+
+postgresql{{ release }}-devel-{{ bin }}-alternative-remove:
+  alternatives.remove:
+    - name: {{ bin }}
+    - path: {{ path }}
+        {% if grains.os in ('Fedora', 'CentOS',) %}
+        {# bypass bug #}
+    - onlyif: alternatives --display {{ bin }}
+        {% else %}
+    - onlyif: test -f {{ path }}
+        {% endif %}
+    - require_in:
+      - pkg: postgresql{{ release }}-devel-pkgs-removed
+      {%- endfor %}
+    {%- endif %}
+
+postgresql{{ release }}-devel-pkgs-removed:
+  pkg.purged:
+    - pkgs:
+      - postgresql-dev
+      - postgresql-dev-{{ release|replace('.', '') }}
+      - postgresql-server-dev
+      - postgresql-server-dev-{{ release|replace('.', '') }}
+      - postgresql{{ release }}-jdbc
+      - postgresql{{ release|replace('.', '') }}-jdbc
+      - postgresql-{{ release }}
+      - postgresql-{{ release|replace('.', '') }}
+      - {{ postgres.pkg_python or "postgresql-python" }}
+
+  {% endfor %}
+
+{%- endif %}

--- a/postgres/dropped.sls
+++ b/postgres/dropped.sls
@@ -1,32 +1,5 @@
-{% from tpldir + "/map.jinja" import postgres with context %}
 
-postgresql-dead:
-  service.dead:
-    - name: {{ postgres.service }}
-
-postgresql-removed:
-  pkg.removed:
-    - pkgs:
-      {% if postgres.pkg %}
-      - {{ postgres.pkg }}
-      {% endif %}
-      {% if postgres.pkg_client %}
-      - {{ postgres.pkg_client }}
-      {% endif %}
-      {% if postgres.pkg_dev %}
-      - {{ postgres.pkg_dev }}
-      {% endif %}
-      {% if postgres.pkg_libpq_dev %}
-      - {{ postgres.pkg_libpq_dev }}
-      {% endif %}
-      {% if postgres.pkgs_extra %}
-      {% for pkg in postgres.pkgs_extra %}
-      - {{ pkg }}
-      {% endfor %}
-      {% endif %}
-
-postgres-dir-absent:
-  file.absent:
-    - names:
-      - {{ postgres.conf_dir }}
-      - {{ postgres.data_dir }}
+include:
+  - postgres.server.remove
+  - postgres.client.remove
+  - postgres.dev.remove

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -3,5 +3,7 @@
 Fedora:
   pkg_repo:
     baseurl: 'https://download.postgresql.org/pub/repos/yum/{{ repo.version }}/fedora/fedora-$releasever-$basearch'
+  remove:
+    releases: ['9.4', '9.5', '9.6', '10',]
 
 # vim: ft=sls

--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -36,10 +36,10 @@ postgresql-server:
     - group: wheel
     - require_in:
       - service: postgresql-running
-  {%- else %}
+
 
 # Alternatives system. Make server binaries available in $PATH
-    {%- if 'bin_dir' in postgres and postgres.linux.altpriority %}
+  {%- elif 'bin_dir' in postgres and postgres.linux.altpriority %}
       {%- for bin in postgres.server_bins %}
         {%- set path = salt['file.join'](postgres.bin_dir, bin) %}
 
@@ -56,9 +56,7 @@ postgresql-{{ bin }}-altinstall:
       - cmd: postgresql-cluster-prepared
 
       {%- endfor %}
-    {%- endif %}
-
-{%- endif %}
+  {%- endif %}
 
 postgresql-cluster-prepared:
   file.directory:

--- a/postgres/server/remove.sls
+++ b/postgres/server/remove.sls
@@ -1,0 +1,89 @@
+{%- from "postgres/map.jinja" import postgres with context %}
+
+postgresql-dead:
+  service.dead:
+    - name: {{ postgres.service }}
+    - enable: False
+
+postgresql-repo-removed:
+  pkgrepo.absent:
+    - name: {{ postgres.pkg_repo.name }}
+    {%- if 'pkg_repo_keyid' in postgres %}
+    - keyid: {{ postgres.pkg_repo_keyid }}
+    {%- endif %}
+
+#remove release installed by formula
+postgresql-server-removed:
+  pkg.removed:
+    - pkgs:
+      {% if postgres.pkg %}
+      - {{ postgres.pkg }}
+      {% endif %}
+      {% if postgres.pkgs_extra %}
+      {% for pkg in postgres.pkgs_extra %}
+      - {{ pkg }}
+      {% endfor %}
+      {% endif %}
+
+{%- if postgres.remove.multiple_releases %}
+    #search for and cleandown multiple releases
+
+  {% for release in postgres.remove.releases %}
+postgresql{{ release }}-server-pkgs-removed:
+  pkg.purged:
+    - pkgs:
+      - {{ postgres.pkg if postgres.pkg else "postgresql" }}
+      - postgresql-server
+      - postgresql-libs
+      - postgresql-contrib
+      - postgresql-server-{{ release }}
+      - postgresql-libs-{{ release }}
+      - postgresql-contrib-{{ release }}
+      - postgresql{{ release }}-contrib
+      - postgresql{{ release }}-server
+      - postgresql{{ release }}-libs
+      - postgresql{{ release }}-contrib
+      - postgresql{{ release|replace('.', '') }}-contrib
+      - postgresql{{ release|replace('.', '') }}-server
+      - postgresql{{ release|replace('.', '') }}-libs
+      - postgresql{{ release|replace('.', '') }}-contrib
+
+    {% if 'bin_dir' in postgres %}
+      {% for bin in postgres.server_bins %}
+        {% set path = '/usr/pgsql-' + release|string + '/bin/' + bin %}
+
+postgresql{{ release }}-server-{{ bin }}-alternative-remove:
+  alternatives.remove:
+    - name: {{ bin }}
+    - path: {{ path }}
+      {% if grains.os in ('Fedora', 'CentOS',) %}
+      {# bypass bug #}
+    - onlyif: alternatives --display {{ bin }}
+      {% else %}
+    - onlyif: test -f {{ path }}
+      {% endif %}
+
+      {% endfor %}
+    {% endif %}
+
+    {%- if postgres.remove.data %}
+      #allow data loss? default is no
+postgresql{{ release }}-dataconf-removed:
+  file.absent:
+    - names:
+      - {{ postgres.conf_dir }}
+      - {{ postgres.data_dir }}
+      - /var/lib/postgresql
+      - /var/lib/pgsql
+
+      {% for name, tblspace in postgres.tablespaces|dictsort() %}
+postgresql{{ release }}-tablespace-dir-{{ name }}-removed:
+  file.absent:
+    - name: {{ tblspace.directory }}
+    - require:
+      - file: postgresql{{ release }}-dataconf-removed 
+      {% endfor %}
+    {% endif %}
+
+  {% endfor %}
+{%- endif %}


### PR DESCRIPTION
The current formula has undocumented `dropped` state.  I would like better support for the REMOVE Use Case.  So this PR (replaces #182) aims to improve that UC.  Comments welcomed.

**CHANGELOG**
1. Remove states documented in `README`
2. New pillars added to `pillar.example` and `README`
3. `dropped.sls` is now meta-state.
4.  `postgres.server.remove` state introduced to replace dropped.sls 
       - Standard UC: remove version
       - Protect data as default (`postgres.remove.data: False`).
       - Extended UC: remove multiple version**s** (`postgres.remove.multiple_releases: True`)
       - Extended UC: remove linux alternatives.
5. `postgres.client.remove`
       - Standard UC (remove one version) and Extended UC (multiple releases).
6. `postgres.dev.remove`
       - Standard UC (remove one version) and Extended UC (multiple releases).
       - Handle `python_pkg` removal too.
7. Added `dev/` directory.  

We could consider moving `dev.sls` and `python.sls` to this `dev` directory.

**Verification**

_top.sls_
base:
  '*':
    - postgres.dropped
    - postgres

_pillars_
```
  #following is used by 'remove' states.
  remove:
    data: True   #(default False)
    multiple_releases: True   #(default False)
    releases: ['9.2', '9.3', '9.4', '9.5', '9.6', '10',]    #(default shown) used when multiple_releases=True
```
_scenarios (+ linux alternatives)_:
- `use_upstream_repo: False`
- `use_upstream_repp: True` and `version: '9.6'`

_Targets_
- Ubuntu 16, 
- Fedora 27,
- Centos 7.

The verification looks good.  Here is summary of the high.state results - with failures noted.
```
UBUNTU 16: use_upstream_repo=False

    Warnings: 'extensions' and 'schemas' are invalid keyword arguments for
              'postgres_database.present'. If you were trying to pass additional
              data to be used in a template context, please populate 'context'
              with 'key: value' pairs. Your approach will work until Salt
              Fluorine is out. Please update your state files.

Succeeded: 74 (changed=24)
Failed:     0
Warnings:   1


FEDORA 27 use_upstream_repo=False


[WARNING ] The function "module.run" is using its deprecated version and will expire in version "Sodium".
[ERROR   ] Exception raised when processing __virtual__ function for salt.loaded.int.utils.boto. Module will not be loaded: 'module' object has no attribute '__version__'
[WARNING ] salt.loaded.int.utils.boto.__virtual__() is wrongly returning `None`. It should either return `True`, `False` or a new name. If you're the developer of the module 'boto', please fix this.
[ERROR   ] Exception raised when processing __virtual__ function for salt.loaded.int.utils.boto3. Module will not be loaded: 'module' object has no attribute '__version__'
[WARNING ] salt.loaded.int.utils.boto3.__virtual__() is wrongly returning `None`. It should either return `True`, `False` or a new name. If you're the developer of the module 'boto3', please fix this.
[ERROR   ] The named service postgresql is not available
[ERROR   ] Command '[u'/bin/psql', u'--no-align', u'--no-readline', u'--no-psqlrc', u'--no-password', u'--dbname', u'postgres', u'-c', u'CREATE TABLESPACE "my_space" OWNER "localUser" LOCATION \'/srv/my_tablespace\' ']' failed with return code: 1
[ERROR   ] stderr: ERROR:  could not set permissions on directory "/srv/my_tablespace": Permission denied
[ERROR   ] retcode: 1
[ERROR   ] Error connecting to Postgresql server
[ERROR   ] An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/state.py", line 1905, in call
    **cdata['kwargs'])
  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1830, in wrapper
    return f(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/salt/states/postgres_tablespace.py", line 121, in present
    if tblspaces[name]['Location'] != directory and not __opts__['test']:
KeyError: u'my_space'

[ERROR   ] Failed to install extension uuid-ossp

Succeeded: 64 (changed=16)
Failed:     3



FEDORA 27: use_upstream_repo: True,  version: 9.6

$ sudo salt-call state.highstate --local
[ERROR   ] Exception raised when processing __virtual__ function for salt.loaded.int.utils.boto. Module will not be loaded: 'module' object has no attribute '__version__'
[WARNING ] salt.loaded.int.utils.boto.__virtual__() is wrongly returning `None`. It should either return `True`, `False` or a new name. If you're the developer of the module 'boto', please fix this.
[ERROR   ] Exception raised when processing __virtual__ function for salt.loaded.int.utils.boto3. Module will not be loaded: 'module' object has no attribute '__version__'
[WARNING ] salt.loaded.int.utils.boto3.__virtual__() is wrongly returning `None`. It should either return `True`, `False` or a new name. If you're the developer of the module 'boto3', please fix this.
[ERROR   ] alternative: pg_resetxlog does not exist
[ERROR   ] alternative: postgresql96-check-db-dir does not exist
[ERROR   ] alternative: postgresql96-setup does not exist
[ERROR   ] Exception raised when processing __virtual__ function for  BOTO BOTO BOTO ETC BLA BLA

[ERROR   ] alternative: initdb does not exist
[ERROR   ] alternative: pg_controldata does not exist
[ERROR   ] alternative: pg_ctl does not exist
[ERROR   ] alternative: postgres does not exist
[ERROR   ] alternative: postmaster does not exist
[ERROR   ] alternative: createlang does not exist
[ERROR   ] alternative: droplang does not exist
[ERROR   ] alternative: pg_receivexlog does not exist
[ERROR   ] alternative: pg_xlogdump does not exist
[ERROR   ] alternative: clusterdb does not exist
[ERROR   ] alternative: createdb does not exist
[ERROR   ] alternative: createuser does not exist
[ERROR   ] alternative: dropdb does not exist
[ERROR   ] alternative: dropuser does not exist
[ERROR   ] alternative: pg_archivecleanup does not exist
[ERROR   ] alternative: pg_basebackup does not exist
[ERROR   ] alternative: pg_config does not exist
[ERROR   ] alternative: pg_dump does not exist
[ERROR   ] alternative: pg_dumpall does not exist
[ERROR   ] alternative: pg_isready does not exist
[ERROR   ] alternative: pg_restore does not exist
[ERROR   ] alternative: pg_rewind does not exist
[ERROR   ] alternative: pg_test_fsync does not exist
[ERROR   ] alternative: pg_test_timing does not exist
[ERROR   ] alternative: pg_upgrade does not exist
[ERROR   ] alternative: pgbench does not exist
[ERROR   ] alternative: psql does not exist
[ERROR   ] alternative: reindexdb does not exist
[ERROR   ] alternative: vacuumdb does not exist
[ERROR   ] alternative: ecg does not exist
[ERROR   ] Exception raised when processing __virtual__ function for BOTO BOTO BOTO ETC..

[WARNING ] The function "module.run" is using its deprecated version and will expire in version "Sodium".
[ERROR   ] The named service postgresql-9.6 is not available
[ERROR   ] Failed to install extension uuid-ossp

    Warnings: 'extensions' and 'schemas' are invalid keyword arguments for
              'postgres_database.present'. If you were trying to pass additional
              data to be used in a template context, please populate 'context'
              with 'key: value' pairs. Your approach will work until Salt
              Fluorine is out. Please update your state files.


Succeeded: 297 (changed=108)
Failed:      1
Warnings:    1



UBUNTU: use_upstream_repo: True     version: 9.6

[ERROR   ] {'removed': {}, 'installed': {}}
[WARNING ] The function "module.run" is using its deprecated version and will expire in version "Sodium".

          ID: postgresql10-server-pkgs-removed
    Function: pkg.purged
      Result: False
     Comment: The following packages failed to purge: postgresql-contrib-10.
     Started: 15:21:04.912864
    Duration: 1411.552 ms
     Changes:   
              ----------
              installed:
                  ----------
              removed:
                  ----------

Succeeded: 74 (changed=25)
Failed:     1
Warnings:   1


CENTOS7: use_upstream_rep: False

$ sudo salt-call state.highstate --local
[WARNING ] The function "module.run" is using its deprecated version and will expire in version "Sodium".
[ERROR   ] The named service postgresql is not available
[ERROR   ] Command '['/bin/psql', '--no-align', '--no-readline', '--no-psqlrc', '--no-password', '--dbname', 'postgres', '-c', 'CREATE TABLESPACE "my_space" OWNER "localUser" LOCATION \'/srv/my_tablespace\' ']' failed with return code: 1
[ERROR   ] stderr: ERROR:  could not set permissions on directory "/srv/my_tablespace": Permission denied
[ERROR   ] retcode: 1
[ERROR   ] Error connecting to Postgresql server
[ERROR   ] An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/state.py", line 1851, in call
    **cdata['kwargs'])
  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1795, in wrapper
    return f(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/salt/states/postgres_tablespace.py", line 121, in present
    if tblspaces[name]['Location'] != directory and not __opts__['test']:
KeyError: 'my_space'

[ERROR   ] Failed to install extension uuid-ossp


Succeeded: 64 (changed=16)
Failed:     3
-------------

CENTOS7: use_upstream_repo: True   version: 9.6


$ sudo salt-call state.highstate --local
[ERROR   ] alternative: pg_resetxlog does not exist
[ERROR   ] alternative: postgresql96-check-db-dir does not exist
[ERROR   ] alternative: postgresql96-setup does not exist
[ERROR   ] alternative: initdb does not exist
[ERROR   ] alternative: pg_controldata does not exist
[ERROR   ] alternative: pg_ctl does not exist
[ERROR   ] alternative: postgres does not exist
[ERROR   ] alternative: postmaster does not exist
[ERROR   ] alternative: clusterdb does not exist
[ERROR   ] alternative: createdb does not exist
[ERROR   ] alternative: createlang does not exist
[ERROR   ] alternative: createuser does not exist
[ERROR   ] alternative: dropdb does not exist
[ERROR   ] alternative: droplang does not exist
[ERROR   ] alternative: dropuser does not exist
[ERROR   ] alternative: pg_archivecleanup does not exist
[ERROR   ] alternative: pg_basebackup does not exist
[ERROR   ] alternative: pg_config does not exist
[ERROR   ] alternative: pg_dump does not exist
[ERROR   ] alternative: pg_dumpall does not exist
[ERROR   ] alternative: pg_isready does not exist
[ERROR   ] alternative: pg_receivexlog does not exist
[ERROR   ] alternative: pg_restore does not exist
[ERROR   ] alternative: pg_rewind does not exist
[ERROR   ] alternative: pg_test_fsync does not exist
[ERROR   ] alternative: pg_test_timing does not exist
[ERROR   ] alternative: pg_upgrade does not exist
[ERROR   ] alternative: pg_xlogdump does not exist
[ERROR   ] alternative: pgbench does not exist
[ERROR   ] alternative: psql does not exist
[ERROR   ] alternative: reindexdb does not exist
[ERROR   ] alternative: vacuumdb does not exist
[ERROR   ] alternative: ecg does not exist
[WARNING ] The function "module.run" is using its deprecated version and will expire in version "Sodium".
[ERROR   ] The named service postgresql-9.6 is not available
[ERROR   ] Failed to install extension uuid-ossp

Succeeded: 297 (changed=56)
Failed:      1
Warnings:    1
```
