### PR TITLE
Fix file.managed for macos

### DIFF
--- a/postgres/dev/init.sls
+++ b/postgres/dev/init.sls
@@ -40,7 +40,7 @@ postgresql-{{ bin }}-altinstall:
 postgres_maxfiles_limits_conf:
   file.managed:
     - name: /Library/LaunchDaemons/limit.maxfiles.plist
-    - source: salt://{{ tpldir }}/../templates/limit.maxfiles.plist
+    - source: salt://postgres/templates/limit.maxfiles.plist
     - template: jinja
     - context:
       soft_limit: {{ postgres.limits.soft }}
@@ -59,7 +59,7 @@ postgres-desktop-shortcut-clean:
 postgres-desktop-shortcut-add:
   file.managed:
     - name: /tmp/mac_shortcut.sh
-    - source: salt://{{ tpldir }}/templates/mac_shortcut.sh
+    - source: salt://postgres/templates/mac_shortcut.sh
     - mode: 755
     - template: jinja
     - context:


### PR DESCRIPTION
PR fixes state failure on MacOS.
```
          ID: postgres_maxfiles_limits_conf
    Function: file.managed
        Name: /Library/LaunchDaemons/limit.maxfiles.plist
      Result: False
     Comment: Source file salt://postgres/dev/templates/limit.maxfiles.plist not found
```