### PR TITLE
Make the preparation/initdb optional

### DIFF
--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -16,6 +16,7 @@ postgres:
   group: postgres
 
   prepare_cluster:
+    run: True
     pgcommand: initdb -D
     pgtestfile: PG_VERSION
     user: postgres

--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -101,7 +101,11 @@ postgresql-config-dir:
       - ignore_files
     - makedirs: True
     - require:
+      {%- if postgres.prepare_cluster.run %}
       - cmd: postgresql-cluster-prepared
+      {%- else %}
+      - file: postgresql-cluster-prepared
+      {%- endif %}
 
 {%- set db_port = salt['config.option']('postgres.port') %}
 {%- if db_port %}

--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -67,6 +67,7 @@ postgresql-cluster-prepared:
     - recurse:
       - user
       - group
+{%- if postgres.prepare_cluster.run %}
   cmd.run:
  {%- if postgres.prepare_cluster.command is defined %}
       {# support for depreciated 'prepare_cluster.command' pillar #}
@@ -84,6 +85,7 @@ postgresql-cluster-prepared:
       - file: postgresql-cluster-prepared
     - watch_in:
       - module: postgresql-service-restart
+{%- endif %}
 
 postgresql-config-dir:
   file.directory:


### PR DESCRIPTION
In some situations it's nice not to require the cluster to be prepared, e.g. when we are working with standbys that will be synchronized using repmgr. This makes it an option, that is set to True by default to make the state work the same way it used to.

This could blso be an occasion to add prepare_cluster examples in the pillar file.