### PR TITLE
Fix 'requisites were not found'

### DIFF
--- a/postgres/manage.sls
+++ b/postgres/manage.sls
@@ -51,8 +51,8 @@ postgres-reload-modules:
 {{ format_state( name + '-' + ext_name, 'postgres_extension', extension) }}
     - require:
       - postgres_database: postgres_database-{{ name }}
-      {%- if 'schema' in extension %}
-      - postgres_schema: postgres_schema-{{ extension.schema }}
+      {%- if 'schema' in extension and 'schemas' in postgres %}
+      - postgres_schema: postgres_schema-{{ name }}-{{ extension.schema }}
       {%- endif %}
     
     {%- endfor %}


### PR DESCRIPTION
This PR fixes `postgres_extension.present` state  failure when extensions/schemas are used.
Before (broken):
```
 ID: postgres_extension-db2-uuid-ossp
    Function: postgres_extension.present
        Name: uuid-ossp
      Result: False
     Comment: The following requisites were not found:
                                 require:
                                     postgres_schema: postgres_schema-public
     Started: 07:27:31.252118
```
After (fixed)
```
 ID: postgres_extension-db2-uuid-ossp
    Function: postgres_extension.present
        Name: uuid-ossp
      Result: False
     Comment: One or more requisite failed: postgres.manage.postgres_database-db2, postgres.manage.postgres_schema-db2-public
     Started: 08:54:01.289645
```