### PR TITLE
selinux fcontext for postgres_database.present

### DIFF
--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -223,6 +223,29 @@ postgresql-tablespace-dir-{{ name }}:
     - require:
       - pkg: postgresql-server
 
+    {%- if "selinux" in grains and grains.selinux.enabled %}
+
+  pkg.installed:
+    - names:
+      - policycoreutils-python
+      - selinux-policy-targeted
+    - refresh: True
+  selinux.fcontext_policy_present:
+    - name: '{{ tblspace.directory }}(/.*)?'
+    - sel_type: postgresql_db_t
+    - require:
+      - file: postgresql-tablespace-dir-{{ name }}
+      - pkg: postgresql-tablespace-dir-{{ name }}
+
+postgresql-tablespace-dir-{{ name }}-fcontext:
+  selinux.fcontext_policy_applied:
+    - name: {{ tblspace.directory }}
+    - recursive: True
+    - require:
+      - selinux: postgresql-tablespace-dir-{{ name }}
+
+    {%- endif %}
+
 {%- endfor %}
 
 {%- if not postgres.bake_image %}


### PR DESCRIPTION
This PR fixes #186 finally.  

All `postgres_database.present` states need a fcontext.  This example from  `pillar.example`  ....
```
  # tablespaces to be created
  tablespaces:
    my_space:
      directory: /srv/my_tablespace            #<== new directory ....
      owner: localUser

  databases:
  ...
    db2:
      owner: 'remoteUser'
      template: 'template0'
      lc_ctype: 'en_US.UTF-8'
      lc_collate: 'en_US.UTF-8'
      tablespace: 'my_space'        #<== `postgres_database.present` will fail
```


**Verified on Centos7 with selinux enforcing**
```
ID: postgresql-tablespace-dir-my_space
    Function: file.directory
        Name: /srv/bob/my_tablespace
      Result: True
     Comment: Directory /srv/bob/my_tablespace is in the correct state
              Directory /srv/bob/my_tablespace updated
     Started: 13:13:06.584321
    Duration: 78.609 ms
     Changes:
----------
          ID: postgresql-tablespace-dir-my_space
    Function: pkg.installed
        Name: policycoreutils-python
      Result: True
     Comment: All specified packages are already installed
     Started: 13:13:06.663076
    Duration: 0.504 ms

          ID: postgresql-tablespace-dir-my_space
    Function: pkg.installed
        Name: selinux-policy-targeted
      Result: True
     Comment: All specified packages are already installed
     Started: 13:13:06.663680
    Duration: 0.37 ms
     Changes:
----------
          ID: postgresql-tablespace-dir-my_space
    Function: selinux.fcontext_policy_present
        Name: /srv/bob/my_tablespace(/.*)?
      Result: True
     Comment: SELinux policy for "/srv/bob/my_tablespace(/.*)?" already present with specified filetype "all files" and sel_type "postgresql_db_t".
     Started: 13:13:06.664657
    Duration: 175.454 ms
     Changes:
----------
          ID: postgresql-tablespace-dir-my_space-fcontext
    Function: selinux.fcontext_policy_applied
        Name: /srv/bob/my_tablespace
      Result: True
     Comment: SElinux policies are already applied for filespec "/srv/bob/my_tablespace"
     Started: 13:13:06.840530
    Duration: 11.444 ms
```
**Solves the problem**
```
          ID: postgres_database-db2
    Function: postgres_database.present
        Name: db2
      Result: True
     Comment: Database db2 is already present
```