### PR TITLE
FreeBSD support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,16 @@ Installs the PostgreSQL adapter for Python on Linux.
 Installs the PostgreSQL server package on Linux, prepares the DB cluster and starts the server using
 packaged init script, job or unit.
 
+
+.. note::
+
+    For PostgreSQL server before version 10 to work inside a **FreeBSD Jail**
+    set ``sysvshm=new`` and ``sysvsem=new``.
+    DO NOT SET ``allow.sysvipc=1``. It defeats the purpose of using Jails.
+
+    Further information: https://blog.tyk.nu/blog/freebsd-jails-and-sysv-ipc/
+
+
 ``postgres.server.image``
 -------------------------
 

--- a/postgres/osfamilymap.yaml
+++ b/postgres/osfamilymap.yaml
@@ -21,8 +21,13 @@ Debian:
     {% endif %}
 
 FreeBSD:
-  user: pgsql
+  user: &freebsd-user pgsql
+  group: &freebsd-group pgsql
   pkg_client: postgresql{{ release }}-client
+  pkg: postgresql{{ release }}-server
+  prepare_cluster:
+    user: *freebsd-user
+    group: *freebsd-group
 
 OpenBSD:
   conf_dir: /var/postgresql/data

--- a/postgres/osfamilymap.yaml
+++ b/postgres/osfamilymap.yaml
@@ -21,6 +21,8 @@ Debian:
     {% endif %}
 
 FreeBSD:
+  conf_dir: /usr/local/pgsql/data
+  data_dir: /usr/local/pgsql/data
   user: &freebsd-user pgsql
   group: &freebsd-group pgsql
   pkg_client: postgresql{{ release }}-client

--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -207,6 +207,11 @@ postgresql-pg_ident:
 {%- endif %}
     - require:
       - file: postgresql-config-dir
+      {%- if postgres.prepare_cluster.run %}
+      - cmd: postgresql-cluster-prepared
+      {%- else %}
+      - file: postgresql-cluster-prepared
+      {%- endif %}
 
 {%- for name, tblspace in postgres.tablespaces|dictsort() %}
 


### PR DESCRIPTION
- Mainly path and name adjustments
- Added a hint for running inside FreeBSD jail.

Tested on

- FreeBSD 11.2
- Ubuntu 18.04