### PR TITLE
Fix #236: Restart postgres service after ACL changes in pg_hba.conf

### DIFF
--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -147,13 +147,6 @@ postgresql-conf:
 
 {%- endif %}
 
-# Restart the service where reloading is not sufficient
-# Currently when the cluster is created or changes made to `postgresql.conf`
-postgresql-service-restart:
-  module.wait:
-    - name: service.restart
-    - m_name: {{ postgres.service }}
-
 {%- set pg_hba_path = salt['file.join'](postgres.conf_dir, 'pg_hba.conf') %}
 
 postgresql-pg_hba:
@@ -180,6 +173,15 @@ postgresql-pg_hba:
 {%- endif %}
     - require:
       - file: postgresql-config-dir
+    - watch_in:
+      - module: postgresql-service-restart
+
+# Restart the service where reloading is not sufficient
+# Currently when the cluster is created or changes made to `postgresql.conf`
+postgresql-service-restart:
+  module.wait:
+    - name: service.restart
+    - m_name: {{ postgres.service }}
 
 {%- set pg_ident_path = salt['file.join'](postgres.conf_dir, 'pg_ident.conf') %}
 

--- a/postgres/templates/pg_ident.conf.j2
+++ b/postgres/templates/pg_ident.conf.j2
@@ -47,5 +47,5 @@
 # MAPNAME       SYSTEM-USERNAME         PG-USERNAME
 
 {%- for mapping in mappings %}
-{{ '{0:<15} {1:<22} {2}'.format(mapping) -}}
+{{ '{0:<15} {1:<22} {2}'.format(*mapping) -}}
 {% endfor %}


### PR DESCRIPTION
**NOTE: This [first commit] is not my work**.

In https://github.com/saltstack-formulas/postgres-formula/issues/236#issuecomment-413680116, I specifically mentioned that this solution was provided by @RobRuana in #216. The specific commit:

* https://github.com/saltstack-formulas/postgres-formula/pull/216/commits/ef87358

I noticed that this issue was still open, so I have set @RobRuana as the author of the commit in an attempt to resolve this issue as well as attribute it accordingly.  If this is inappropriate in any way, I am most happy to close this PR.