### PR TITLE
Only download archive if necessary [macos]

### DIFF
--- a/postgres/macos/postgresapp.sls
+++ b/postgres/macos/postgresapp.sls
@@ -1,18 +1,10 @@
 {%- from salt.file.dirname(tpldir) ~ "/map.jinja" import postgres as pg with context -%}
 
-# Cleanup first
-pg-remove-prev-archive:
-  file.absent:
-    - name: '{{ pg.macos.tmpdir }}/{{ pg.macos.archive }}'
-    - require_in:
-      - pg-extract-dirs
-
 pg-extract-dirs:
   file.directory:
     - names:
       - '{{ pg.macos.tmpdir }}'
     - makedirs: True
-    - clean: True
     - require_in:
       - pg-download-archive
 
@@ -20,11 +12,14 @@ pg-download-archive:
   pkg.installed:
     - name: curl
   cmd.run:
-    - name: curl {{ pg.macos.dl.opts }} -o '{{ pg.macos.tmpdir }}/{{ pg.macos.archive }}' {{ pg.macos.postgresapp.url }}
+    - name: curl {{ pg.macos.dl.opts }} -o {{ pg.macos.tmpdir }}/{{ pg.macos.archive }} {{ pg.macos.postgresapp.url }}
+    - unless: test -f {{ pg.macos.tmpdir }}/{{ pg.macos.archive }}
       {% if grains['saltversioninfo'] >= [2017, 7, 0] %}
     - retry:
         attempts: {{ pg.macos.dl.retries }}
         interval: {{ pg.macos.dl.interval }}
+        until: True
+        splay: 10
       {% endif %}
 
   {%- if pg.macos.postgresapp.sum %}
@@ -33,7 +28,7 @@ pg-check-archive-hash:
      - name: file.check_hash
      - path: '{{ pg.macos.tmpdir }}/{{ pg.macos.archive }}'
      - file_hash: {{ pg.macos.postgresapp.sum }}
-     - onchanges:
+     - require:
        - cmd: pg-download-archive
      - require_in:
        - archive: pg-package-install
@@ -51,14 +46,7 @@ pg-package-install:
       - cmd: pg-download-archive
     - require_in:
       - file: pg-package-install
-      - file: pg-remove-archive
   file.append:
     - name: {{ pg.userhomes }}/{{ pg.user }}/.bash_profile
     - text: 'export PATH=$PATH:/Applications/Postgres.app/Contents/Versions/latest/bin'
-
-pg-remove-archive:
-  file.absent:
-    - name: '{{ pg.macos.tmpdir }}'
-    - onchanges:
-      - macpackage: pg-package-install
 


### PR DESCRIPTION
It's wasteful downloading fresh archive when cached one is okay (with valid checkum).   

This PR will not download if already existing - but will check the checksum.