### PR TITLE
fix(server/init): use `|json` to resolve `2019.2` breaking change

### DIFF
--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -17,7 +17,7 @@ include:
 # Install, configure and start PostgreSQL server
 postgresql-server:
   pkg.installed:
-    - pkgs: {{ pkgs }}
+    - pkgs: {{ pkgs | json }}
 {%- if postgres.use_upstream_repo == true %}
     - refresh: True
     - require:


### PR DESCRIPTION
* Close #253:
  - Already tested there

---

Fix confirmation: https://github.com/saltstack-formulas/postgres-formula/issues/253#issuecomment-470860840.