### PR TITLE
Always retry alternatives.install state

### DIFF
--- a/postgres/client/init.sls
+++ b/postgres/client/init.sls
@@ -39,6 +39,9 @@ postgresql-{{ bin }}-altinstall:
     - onlyif: test -f {{ path }}
     - require:
       - pkg: postgresql-client-libs
+    - retry:
+        attempts: 2
+        until: True
 
     {%- endfor %}
 {%- endif %}

--- a/postgres/client/init.sls
+++ b/postgres/client/init.sls
@@ -39,9 +39,11 @@ postgresql-{{ bin }}-altinstall:
     - onlyif: test -f {{ path }}
     - require:
       - pkg: postgresql-client-libs
+      {%- if grains['saltversioninfo'] < [2018, 11, 0, 0] %}
     - retry:
         attempts: 2
         until: True
+      {%- endif %}
 
     {%- endfor %}
 {%- endif %}

--- a/postgres/dev/init.sls
+++ b/postgres/dev/init.sls
@@ -23,14 +23,12 @@ postgresql-{{ bin }}-altinstall:
     - link: {{ salt['file.join']('/usr/bin', bin) }}
     - path: {{ path }}
     - priority: {{ postgres.linux.altpriority }}
-      {% if grains.os in ('Fedora', 'CentOS',) %} {# bypass bug #}
-    - onlyif: alternatives --display {{ bin }}
-      {% else %}
     - onlyif: test -f {{ path }}
+      {%- if grains['saltversioninfo'] < [2018, 11, 0, 0] %}
     - retry:
         attempts: 2
         until: True
-      {% endif %}
+      {%- endif %}
 
     {%- endfor %}
   {%- endif %}

--- a/postgres/dev/init.sls
+++ b/postgres/dev/init.sls
@@ -27,6 +27,9 @@ postgresql-{{ bin }}-altinstall:
     - onlyif: alternatives --display {{ bin }}
       {% else %}
     - onlyif: test -f {{ path }}
+    - retry:
+        attempts: 2
+        until: True
       {% endif %}
 
     {%- endfor %}

--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -54,9 +54,11 @@ postgresql-{{ bin }}-altinstall:
       - pkg: postgresql-server
     - require_in:
       - cmd: postgresql-cluster-prepared
+        {%- if grains['saltversioninfo'] < [2018, 11, 0, 0] %}
     - retry:
         attempts: 2
         until: True
+        {%- endif %}
 
       {%- endfor %}
   {%- endif %}

--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -54,6 +54,9 @@ postgresql-{{ bin }}-altinstall:
       - pkg: postgresql-server
     - require_in:
       - cmd: postgresql-cluster-prepared
+    - retry:
+        attempts: 2
+        until: True
 
       {%- endfor %}
   {%- endif %}


### PR DESCRIPTION
This PR introduces retries because salt `alternatives.install` sometimes fails on 1st run.

Verified on SuSE