### PR TITLE
fix(uuid-ossp): use hyphen consistently

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -174,14 +174,14 @@ postgres:
 
   # optional schemas to enable on database
   schemas:
-    uuid_ossp:
+    uuid-ossp:
       dbname: db1
       owner: localUser
 
   # optional extensions to install in schema
   extensions:
     uuid-ossp:
-      schema: uuid_ossp
+      schema: uuid-ossp
       maintenance_db: db1
     #postgis: {}
 


### PR DESCRIPTION
* Found when testing Travis CI for the formula
* States fail ~and run in the wrong order~
* Broken: https://travis-ci.org/myii/postgres-formula/jobs/524227136#L2092
* Fixed: https://travis-ci.org/myii/postgres-formula/jobs/524229384#L2086

---

Update: While it definitely fixes things, that's only for `Debian` based images so far.