### PR TITLE
fix(freebsd-user): fix FreeBSD daemon's user for PostgreSQL >= 9.6

### DIFF
--- a/postgres/osfamilymap.yaml
+++ b/postgres/osfamilymap.yaml
@@ -21,10 +21,17 @@ Debian:
     {% endif %}
 
 FreeBSD:
-  conf_dir: /usr/local/pgsql/data
-  data_dir: /usr/local/pgsql/data
+    {% if repo.version|float >= 9.6 %}
+  user: &freebsd-user postgres
+  group: &freebsd-group postgres
+  conf_dir: {{ '/var/db/postgres/data' ~ release  }}
+  data_dir: {{ '/var/db/postgres/data' ~ release }}
+    {% else %}
   user: &freebsd-user pgsql
   group: &freebsd-group pgsql
+  conf_dir: /usr/local/pgsql/data
+  data_dir: /usr/local/pgsql/data
+    {% endif %}
   pkg_client: postgresql{{ release }}-client
   pkg: postgresql{{ release }}-server
   prepare_cluster:


### PR DESCRIPTION
For postgresql 9.6 and newer, the default unix user used by postgresql
daemon has changed to 'postgres', and the default data directory is:
/var/db/postgres/data96
For further details see : [revision 421360](https://svnweb.freebsd.org/ports/head/UPDATING?view=markup&pathrev=421360)

Closes #263