### PR TITLE
feat(debian): add buster support

### DIFF
--- a/postgres/codenamemap.yaml
+++ b/postgres/codenamemap.yaml
@@ -54,12 +54,14 @@
 {{ debian_codename('wheezy', '9.1') }}
 {{ debian_codename('jessie', '9.4') }}
 {{ debian_codename('stretch', '9.6') }}
+{{ debian_codename('buster', '11') }}
 
 # `oscodename` grain has long distro name
 # if `lsb-release` package not installed
 {{ debian_codename('wheezy', '9.1', 'Debian GNU/Linux 7 (wheezy)') }}
 {{ debian_codename('jessie', '9.4', 'Debian GNU/Linux 8 (jessie)') }}
 {{ debian_codename('stretch', '9.6', 'Debian GNU/Linux 9 (stretch)') }}
+{{ debian_codename('buster', '11', 'Debian GNU/Linux 10 (buster)') }}
 
 ## Ubuntu
 {{ debian_codename('trusty', '9.3') }}

--- a/postgres/codenamemap.yaml
+++ b/postgres/codenamemap.yaml
@@ -50,7 +50,7 @@
 
 {% endmacro %}
 
-## Debian GNU/Linux
+## Debian GNU/Linux (the second parameter refers to the postgresql package version, not the distro)
 {{ debian_codename('wheezy', '9.1') }}
 {{ debian_codename('jessie', '9.4') }}
 {{ debian_codename('stretch', '9.6') }}


### PR DESCRIPTION
feat(debian): add buster support

This adds support for Debian buster and native package installation. Fixes #276