### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -47,16 +47,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example test/salt/pillar/postgres.sls
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+# 2. All YAML files heavily reliant on Jinja; these can be tackled in a subsequent PR
+ignore: |
+  node_modules/
+  pillar.example
+  postgres/codenamemap.yaml
+  postgres/osfamilymap.yaml
+  postgres/osmap.yaml
+  postgres/repo.yaml
+  test/salt/pillar/postgres.sls
+
+rules:
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/pillar.example
+++ b/pillar.example
@@ -1,24 +1,27 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 # Port to use for the cluster -- can be used to provide a non-standard port
 # NOTE: If already set in the minion config, that value takes priority
 postgres.port: '5432'
 
 postgres:
   # UPSTREAM REPO
-  # Set True to configure upstream postgresql.org repository for YUM/APT/ZYPP
-  use_upstream_repo: False
-  # Version to install from upstream repository (if upstream_repo: True)
+  # Set true to configure upstream postgresql.org repository for YUM/APT/ZYPP
+  use_upstream_repo: false
+  # Version to install from upstream repository (if upstream_repo: true)
   version: '10'
-  # Set True to add a file in /etc/profile.d adding the bin dir in $PATH
+  # Set true to add a file in /etc/profile.d adding the bin dir in $PATH
   # as packages from upstream put them somewhere like /usr/pgsql-10/bin
-  add_profile: False
+  add_profile: false
   # If automatic package installation fails, use `fromrepo` to specify the
-  # upstream repo to install packages from [#133, #185] (if upstream_repo: True)
+  # upstream repo to install packages from [#133, #185] (if upstream_repo: true)
   fromrepo: 'jessie-pgdg'
 
   ### MACOS
   # Set to 'postgresapp' OR 'homebrew' for MacOS
-  #use_upstream_repo: 'postgresapp'
-  #use_upstream_repo: 'homebrew'
+  # use_upstream_repo: 'postgresapp'
+  # use_upstream_repo: 'homebrew'
 
   # PACKAGE
   # These pillars are typically never required.
@@ -27,7 +30,7 @@ postgres:
   # service:
   #   name: 'postgresql'
   #   flags: -w -s -m fast
-  #   sysrc: True
+  #   sysrc: true
   pkgs_extra:
     - postgresql-contrib
     - postgresql-plpython
@@ -39,7 +42,7 @@ postgres:
     locale: en_US.UTF-8
     # encoding: UTF8
 
-  #'Alternatives system' priority incremental. 0 disables feature.
+  # 'Alternatives system' priority incremental. 0 disables feature.
   linux:
     altpriority: 30
 
@@ -62,7 +65,7 @@ postgres:
   # are authenticated, which PostgreSQL user names they can use, which
   # databases they can access. Records take one of these forms:
   #
-  #acls:
+  # acls:
   #  - ['local', 'DATABASE',  'USER',  'METHOD']
   #  - ['host', 'DATABASE',  'USER',  'ADDRESS', 'METHOD']
   #  - ['hostssl', 'DATABASE', 'USER', 'ADDRESS', 'METHOD']
@@ -83,7 +86,7 @@ postgres:
     - ['users_as_appuser', 'jsmith', 'connuser']
 
   # Backup extension for configuration files, defaults to ``.bak``.
-  # Set ``False`` to stop creation of backups when config files change.
+  # Set ``false`` to stop creation of backups when config files change.
   {%- if salt['status.time']|default(none) is callable %}
   config_backup: ".backup@{{ salt['status.time']('%y-%m-%d_%H:%M:%S') }}"
   {%- endif %}
@@ -93,9 +96,9 @@ postgres:
   # If Salt is unable to detect init system running in the scope of state run,
   # probably we are trying to bake a container/VM image with PostgreSQL.
   # Use ``bake_image`` setting to control how PostgreSQL will be started: if set
-  # to ``True`` the raw ``pg_ctl`` will be utilized instead of packaged init
+  # to ``true`` the raw ``pg_ctl`` will be utilized instead of packaged init
   # script, job or unit run with Salt ``service`` state.
-  bake_image: True
+  bake_image: true
 
   {%- endif %}
 
@@ -106,7 +109,7 @@ postgres:
   #
   # Format is the following:
   #
-  #<users|tablespaces|databases|schemas|extensions>:
+  # <users|tablespaces|databases|schemas|extensions>:
   #  NAME:
   #    ensure: <present|absent>  # 'present' is the default
   #    ARGUMENT: VALUE
@@ -117,13 +120,13 @@ postgres:
   #
   # For example, the Pillar:
   #
-  #users:
+  # users:
   #  testUser:
   #    password: test
   #
   # will render such state:
   #
-  #postgres_user-testUser:
+  # postgres_user-testUser:
   #  postgres_user.present:
   #    - name: testUser
   #    - password: test
@@ -131,18 +134,18 @@ postgres:
     localUser:
       ensure: present
       password: '98ruj923h4rf'
-      createdb: False
-      createroles: False
-      inherit: True
-      replication: False
+      createdb: false
+      createroles: false
+      inherit: true
+      replication: false
 
     remoteUser:
       ensure: present
       password: '98ruj923h4rf'
-      createdb: False
-      createroles: False
-      inherit: True
-      replication: False
+      createdb: false
+      createroles: false
+      inherit: true
+      replication: false
 
     absentUser:
       ensure: absent
@@ -183,14 +186,14 @@ postgres:
 
   # optional extensions to install in schema
   extensions:
+    # postgis: {}
     uuid-ossp:
       schema: uuid-ossp
       maintenance_db: db1
-    #postgis: {}
 
   remove:
-    data: True
-    multiple_releases: True
-    releases: ['9.6', '10',]
+    data: true
+    multiple_releases: true
+    releases: ['9.6', '10']
 
 # vim: ft=yaml ts=2 sts=2 sw=2 et

--- a/postgres/codenamemap.yaml
+++ b/postgres/codenamemap.yaml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 ### Set parameters based on PostgreSQL version supplied with particular distro
 
 {% import_yaml "postgres/repo.yaml" as repo %}

--- a/postgres/defaults.yaml
+++ b/postgres/defaults.yaml
@@ -1,8 +1,11 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 # Default lookup dictionary
 
 postgres:
-  use_upstream_repo: True
-  add_profile: False # add bin_dir to $PATH, if installed from repos
+  use_upstream_repo: true
+  add_profile: false  # add bin_dir to $PATH, if installed from repos
   version: '10'
   pkg: postgresql
   pkgs_extra: []
@@ -17,7 +20,7 @@ postgres:
   group: postgres
 
   prepare_cluster:
-    run: True
+    run: true
     pgcommand: initdb -D
     pgtestfile: PG_VERSION
     user: postgres
@@ -37,7 +40,8 @@ postgres:
     archive: postgres.dmg
     tmpdir: /tmp/postgrestmp
     postgresapp:
-      #See: https://github.com/PostgresApp/PostgresApp/releases/
+      # See: https://github.com/PostgresApp/PostgresApp/releases/
+      # yamllint disable-line rule:line-length
       url: https://github.com/PostgresApp/PostgresApp/releases/download/v2.1.1/Postgres-2.1.1.dmg
       sum: sha256=ac0656b522a58fd337931313f09509c09610c4a6078fe0b8e469e69af1e1750b
     homebrew:
@@ -68,10 +72,10 @@ postgres:
   config_backup: '.bak'
 
   service:
-    name:  postgresql
-    sysrc: False
+    name: postgresql
+    sysrc: false
 
-  bake_image: False
+  bake_image: false
 
   fromrepo: ''
 
@@ -82,10 +86,10 @@ postgres:
   extensions: {}
 
   linux:
-    #Alternatives system are disabled by a 'altpriority=0' pillar.
+    # Alternatives system are disabled by a 'altpriority=0' pillar.
     altpriority: 0
 
   remove:
-    data: False
-    multiple_releases: False
-    releases: ['9.2', '9.3', '9.4', '9.5', '9.6', '10',]
+    data: false
+    multiple_releases: false
+    releases: ['9.2', '9.3', '9.4', '9.5', '9.6', '10']

--- a/postgres/osfamilymap.yaml
+++ b/postgres/osfamilymap.yaml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 {% import_yaml "postgres/repo.yaml" as repo %}
 
 {% set release = repo.version|replace('.', '') %}

--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -1,9 +1,11 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 {% import_yaml "postgres/repo.yaml" as repo %}
 
 Fedora:
   pkg_repo:
+    # yamllint disable-line rule:line-length
     baseurl: 'https://download.postgresql.org/pub/repos/yum/{{ repo.version }}/fedora/fedora-$releasever-$basearch'
   remove:
-    releases: ['9.4', '9.5', '9.6', '10',]
-
-# vim: ft=sls
+    releases: ['9.4', '9.5', '9.6', '10']

--- a/postgres/repo.yaml
+++ b/postgres/repo.yaml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 # This file allows to get PostgreSQL version and upstream repo settings
 # early from Pillar to set correct lookup dictionaty items
 

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: default
 title: postgres formula
 maintainer: SaltStack Formulas


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix (or ignore) errors shown below:

```bash
postgres-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
./postgres/repo.yaml
  4:2       error    syntax error: found character '%' that cannot start any token
  6:89      error    line too long (110 > 88 characters)  (line-length)
  9:89      error    line too long (95 > 88 characters)  (line-length)
  13:89     error    line too long (104 > 88 characters)  (line-length)
  14:89     error    line too long (106 > 88 characters)  (line-length)

./postgres/defaults.yaml
  3:1       warning  missing document start "---"  (document-start)
  4:22      warning  truthy value should be one of [false, true]  (truthy)
  5:16      warning  truthy value should be one of [false, true]  (truthy)
  5:22      warning  too few spaces before comment  (comments)
  20:10     warning  truthy value should be one of [false, true]  (truthy)
  40:8      warning  missing starting space in comment  (comments)
  41:89     error    line too long (97 > 88 characters)  (line-length)
  71:11     error    too many spaces after colon  (colons)
  72:12     warning  truthy value should be one of [false, true]  (truthy)
  74:15     warning  truthy value should be one of [false, true]  (truthy)
  85:6      warning  missing starting space in comment  (comments)
  89:11     warning  truthy value should be one of [false, true]  (truthy)
  90:24     warning  truthy value should be one of [false, true]  (truthy)
  91:56     error    too few spaces after comma  (commas)

./postgres/codenamemap.yaml
  3:2       error    syntax error: found character '%' that cannot start any token
  8:89      error    line too long (98 > 88 characters)  (line-length)
  49:89     error    line too long (110 > 88 characters)  (line-length)
  53:89     error    line too long (99 > 88 characters)  (line-length)

./postgres/osmap.yaml
  1:2       error    syntax error: found character '%' that cannot start any token
  5:89      error    line too long (115 > 88 characters)  (line-length)

./postgres/osfamilymap.yaml
  1:2       error    syntax error: found character '%' that cannot start any token
  57:89     error    line too long (90 > 88 characters)  (line-length)
  58:89     error    line too long (113 > 88 characters)  (line-length)
  134:89    error    line too long (103 > 88 characters)  (line-length)
  135:89    error    line too long (127 > 88 characters)  (line-length)
  205:89    error    line too long (91 > 88 characters)  (line-length)
  206:89    error    line too long (91 > 88 characters)  (line-length)

pillar.example
  3:1       warning  missing document start "---"  (document-start)
  8:22      warning  truthy value should be one of [false, true]  (truthy)
  13:16     warning  truthy value should be one of [false, true]  (truthy)
  20:4      warning  missing starting space in comment  (comments)
  21:4      warning  missing starting space in comment  (comments)
  42:4      warning  missing starting space in comment  (comments)
  65:4      warning  missing starting space in comment  (comments)
  87:4      error    syntax error: found character '%' that cannot start any token

test/salt/pillar/postgres.sls
  4:2       error    syntax error: found character '%' that cannot start any token
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.

---

Actually, unlike all of the other formulas where `yamllint` has been introduced (all linking back to the PR linked above), the Jinja dependency is too high throughout most/all YAML files here, so most have been ignored.  I did still fix the lint issues where possible, though.  In the longer-term, the Jinja from these files could be delegated back to the `.jinja` and/or `.sls` files and pure YAML files could be introduced again.  I looked into it and it is definitely within reach but will take considerable effort and testing.