### PR TITLE
fix(freebsd): no libpqdev freebsd package

### DIFF
--- a/postgres/osfamilymap.yaml
+++ b/postgres/osfamilymap.yaml
@@ -35,6 +35,7 @@ FreeBSD:
   conf_dir: /usr/local/pgsql/data
   data_dir: /usr/local/pgsql/data
     {% endif %}
+  pkg_libpq_dev: null  #not in freebsd
   pkg_client: postgresql{{ release }}-client
   pkg: postgresql{{ release }}-server
   prepare_cluster:


### PR DESCRIPTION
Resolve failed state on FreeBSD.
```
 - pkg: No packages available to install matching 'libpq-dev' 
              have been found in the repositories
```