### PR TITLE
fix(macros.jinja): use `user` kwarg for schemas (required on FreeBSD)

### DIFF
--- a/kitchen.vagrant.yml
+++ b/kitchen.vagrant.yml
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+driver:
+  name: vagrant
+
+platforms:
+  - name: freebsd-120-2019-2-py3
+    driver:
+      box_url: https://freebsd.z.vstack.com/FreeBSD-12.0.box
+      cache_directory: false
+      customize:
+        usbxhci: 'off'
+      gui: false
+      linked_clone: true
+      ssh:
+        shell: '/bin/sh'

--- a/postgres/macros.jinja
+++ b/postgres/macros.jinja
@@ -18,7 +18,7 @@
   {%- if 'ensure' in kwarg %}
     {%- set ensure = kwarg.pop('ensure') %}
   {%- endif %}
-  {%- set user_available = False if (state == 'postgres_schema' and grains.saltversioninfo < [2018, 3]) else True %}
+  {%- set user_available = not (state == 'postgres_schema' and grains.saltversioninfo < [2018, 3]) %}
   {%- if 'user' not in kwarg and user_available %}
     {%- do kwarg.update({'user': postgres.user}) %}
   {%- endif -%}

--- a/postgres/macros.jinja
+++ b/postgres/macros.jinja
@@ -18,7 +18,8 @@
   {%- if 'ensure' in kwarg %}
     {%- set ensure = kwarg.pop('ensure') %}
   {%- endif %}
-  {%- if 'user' not in kwarg and state != 'postgres_schema' %}
+  {%- set user_available = False if (state == 'postgres_schema' and grains.saltversioninfo < [2018, 3]) else True %}
+  {%- if 'user' not in kwarg and user_available %}
     {%- do kwarg.update({'user': postgres.user}) %}
   {%- endif -%}
 


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [x] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->

[#119](https://github.com/saltstack-formulas/postgres-formula/pull/119/files?file-filters%5B%5D=.jinja#diff-697d2579726ea5aa6ab2d37645355651R9):

* This was implemented when `user` wasn't available for `postgres_schema` in `2017.7` and earlier (introduced in `2018.3`):
  - https://docs.saltstack.com/en/2017.7/ref/states/all/salt.states.postgres_schema.html

CC: @vutny.

### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

Before:

```sls
       ----------                                                                                                                                                                                                    
                 ID: postgres_schema-db2-public                                                                                                                                                                      
           Function: postgres_schema.present                                                                                                                                                                         
               Name: public                                                                                                                                                                                          
             Result: False                                                                                                                                                                                           
            Comment: An exception occurred in this state: Traceback (most recent call last):                                                                                                                         
                File "/usr/local/lib/python3.6/site-packages/salt/modules/cmdmod.py", line 425, in _run                                                                                                              
                  pwd.getpwnam(runas)                                                                                                                                                                                
              KeyError: "getpwnam(): name not found: 'pgsql'"                                                                                                                                                        
                                                                                                                                                                                                                     
              During handling of the above exception, another exception occurred:                                                                                                                                    
                                                                                                                                                                                                                     
              Traceback (most recent call last):                                                                                                                                                                     
                File "/usr/local/lib/python3.6/site-packages/salt/state.py", line 1933, in call                                                                                                                      
                  **cdata['kwargs'])                                                                                                                                                                                 
                File "/usr/local/lib/python3.6/site-packages/salt/loader.py", line 1939, in wrapper                                                                                                                  
                  return f(*args, **kwargs)                                                                                                                                                                          
                File "/usr/local/lib/python3.6/site-packages/salt/states/postgres_schema.py", line 75, in present                                                                                                    
                  schema_attr = __salt__['postgres.schema_get'](dbname, name, **db_args)                                                                                                                             
                File "/usr/local/lib/python3.6/site-packages/salt/modules/postgres.py", line 2107, in schema_get                                                                                                     
                  db_password=db_password)                                                                                                                                                                           
                File "/usr/local/lib/python3.6/site-packages/salt/modules/postgres.py", line 2162, in schema_list                                                                                                    
                  password=db_password)                                                                                                                                                                              
                File "/usr/local/lib/python3.6/site-packages/salt/modules/postgres.py", line 438, in psql_query                                                                                                      
                  password=password)                                                                                                                                                                                 
                File "/usr/local/lib/python3.6/site-packages/salt/modules/postgres.py", line 377, in _psql_prepare_and_run                                                                                           
                  rcmd, runas=runas, password=password, host=host, port=port, user=user)                                                                                                                             
                File "/usr/local/lib/python3.6/site-packages/salt/modules/postgres.py", line 186, in _run_psql                                                                                                       
                  ret = __salt__['cmd.run_all'](cmd, python_shell=False, **kwargs)                                                                                                                                   
                File "/usr/local/lib/python3.6/site-packages/salt/modules/cmdmod.py", line 2069, in run_all                                                                                                          
                  **kwargs)                                                                                                                                                                                          
                File "/usr/local/lib/python3.6/site-packages/salt/modules/cmdmod.py", line 428, in _run                                                                                                              
                  'User \'{0}\' is not available'.format(runas)                                                                                                                                                      
              salt.exceptions.CommandExecutionError: User 'pgsql' is not available                                                                                                                                   
            Started: 19:40:05.540106                                                                                                                                                                                 
           Duration: 19.641 ms                                                                                                                                                                                       
            Changes:                                                                                                                                                                                                 
       ----------                                                                                                                                                                                                   
                 ID: postgres_schema-uuid-ossp                                                                                                                                                                       
           Function: postgres_schema.present                                                                                                                                                                         
               Name: uuid-ossp                                                                                                                                                                                       
             Result: False                                                                                                                                                                                           
            Comment: An exception occurred in this state: Traceback (most recent call last):                                                                                                                         
                File "/usr/local/lib/python3.6/site-packages/salt/modules/cmdmod.py", line 425, in _run                                                                                                              
                  pwd.getpwnam(runas)                                                                                                                                                                                
              KeyError: "getpwnam(): name not found: 'pgsql'"                                                                                                                                                        
                                                                                                                                                                                                                     
              During handling of the above exception, another exception occurred:                                                                                                                                    
                                                                                                                                                                                                                     
              Traceback (most recent call last):                                                                                                                                                                     
                File "/usr/local/lib/python3.6/site-packages/salt/state.py", line 1933, in call                                                                                                                      
                  **cdata['kwargs'])                                                                                                                                                                                 
                File "/usr/local/lib/python3.6/site-packages/salt/loader.py", line 1939, in wrapper                                                                                                                  
                  return f(*args, **kwargs)                                                                                                                                                                          
                File "/usr/local/lib/python3.6/site-packages/salt/states/postgres_schema.py", line 75, in present                                                                                                    
                  schema_attr = __salt__['postgres.schema_get'](dbname, name, **db_args)                                                                                                                             
                File "/usr/local/lib/python3.6/site-packages/salt/modules/postgres.py", line 2107, in schema_get                                                                                                     
                  db_password=db_password)                                                                                                                                                                           
                File "/usr/local/lib/python3.6/site-packages/salt/modules/postgres.py", line 2162, in schema_list                                                                                                    
                  password=db_password)                                                                                                                                                                              
                File "/usr/local/lib/python3.6/site-packages/salt/modules/postgres.py", line 438, in psql_query                                                                                                      
                  password=password)                                                                                                                                                                                 
                File "/usr/local/lib/python3.6/site-packages/salt/modules/postgres.py", line 377, in _psql_prepare_and_run                                                                                           
                  rcmd, runas=runas, password=password, host=host, port=port, user=user)                                                                                                                             
                File "/usr/local/lib/python3.6/site-packages/salt/modules/postgres.py", line 186, in _run_psql                                                                                                       
                  ret = __salt__['cmd.run_all'](cmd, python_shell=False, **kwargs)                                                                                                                                   
                File "/usr/local/lib/python3.6/site-packages/salt/modules/cmdmod.py", line 2069, in run_all                                                                                                          
                  **kwargs)                                                                                                                                                                                          
                File "/usr/local/lib/python3.6/site-packages/salt/modules/cmdmod.py", line 428, in _run                                                                                                              
                  'User \'{0}\' is not available'.format(runas)                                                                                                                                                      
              salt.exceptions.CommandExecutionError: User 'pgsql' is not available                                                                                                                                   
            Started: 19:40:05.561178                                                                                                                                                                                 
           Duration: 4.004 ms                                                                                                                                                                                        
            Changes:                                                                                                                                                                                                 
       
       Summary for local
       -------------
       Succeeded: 20 (changed=16)
       Failed:     2
       -------------
       Total states run:     22
       Total run time:   47.954 s
```

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

After:

```ruby
  ✔  Postgres service: should be running and enabled                                                                                                                                                                 
     ✔  Service postgresql is expected to be enabled                                                                                                                                                                 
     ✔  Service postgresql is expected to be running                                                                                                                                                                 
     ✔  Port 5432 is expected to be listening                                                                                                                                                                        
  ✔  Postgres configuration: should include the directory                                                                                                                                                            
     ✔  File /srv/my_tablespace is expected to be directory                                                                                                                                                          
     ✔  File /srv/my_tablespace is expected to be owned by "postgres"                                                                                                                                                
     ✔  File /srv/my_tablespace is expected to be grouped into "postgres"                                                                                                                                            
     ✔  File /srv/my_tablespace mode is expected to cmp == "0700"                                                                                                                                                    
  ✔  Postgres command: should match desired lines                                                                                                                                                                    
     ✔  Command: `su - postgres -c 'psql -p5432 -qtc "\l+ db2"'` stdout is expected to match /db2.*remoteUser.*UTF8.*en_US.UTF-8.*en_US.UTF-8.*my_space/                                                             
                                                                                                                                                                                                                     
                                                                                                                                                                                                                     
Profile Summary: 3 successful controls, 0 control failures, 0 controls skipped                                                                                                                                       
Test Summary: 8 successful, 0 failures, 0 skipped
```

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [x] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


