### PR TITLE
fix(archlinux): avoid nonetype error when grain is missing

### DIFF
--- a/postgres/osfamilymap.yaml
+++ b/postgres/osfamilymap.yaml
@@ -62,7 +62,7 @@ RedHat:
     gpgkey: 'https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-{{ release }}'
     baseurl: 'https://download.postgresql.org/pub/repos/yum/{{ repo.version }}/redhat/rhel-$releasever-$basearch'
 
-{%- if grains.get('osmajorrelease') >= 7 %}
+{%- if grains.get('osmajorrelease', 0) >= 7 %}
   pkg_python: python3-psycopg2
 {%- endif %}
 


### PR DESCRIPTION
### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [x] Changes to documentation are appropriate (or tick if not required)
- [x] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

Fix for Archlinux - no `osmajorrelease `grain ;-(

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

n/a

### Debug log showing the bug being fixed
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->
```
    Rendering SLS 'base:postgres.manage' failed: Jinja error: '>=' not supported between instances of 'NoneType' and 'int'
/var/cache/salt/minion/files/base/postgres/osfamilymap.yaml(66):
---
[...]
    humanname: PostgreSQL {{ repo.version }} $releasever - $basearch
    gpgcheck: 1
    gpgkey: 'https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-{{ release }}'
    baseurl: 'https://download.postgresql.org/pub/repos/yum/{{ repo.version }}/redhat/rhel-$releasever-$basearch'

{%- if grains.get('osmajorrelease') >= 7 %}    <======================
  pkg_python: python3-psycopg2
{%- endif %}

{% if repo.use_upstream_repo == true %}
  {% set data_dir = '/var/lib/pgsql/' ~ repo.version ~ '/data' %}
[...]
---
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/salt/utils/templates.py", line 498, in render_jinja_tmpl
    output = template.render(**decoded_context)
  File "/usr/lib/python3.9/site-packages/jinja2/environment.py", line 1090, in render
    self.environment.handle_exception()
  File "/usr/lib/python3.9/site-packages/jinja2/environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "/usr/lib/python3.9/site-packages/jinja2/_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "<template>", line 1, in top-level template code
  File "/usr/lib/python3.9/site-packages/jinja2/environment.py", line 1155, in make_module
    return TemplateModule(self, self.new_context(vars, shared, locals))
  File "/usr/lib/python3.9/site-packages/jinja2/environment.py", line 1238, in __init__
    body_stream = list(template.root_render_func(context))
  File "/var/cache/salt/minion/files/base/postgres/map.jinja", line 2, in top-level template code
    {% import_yaml "postgres/osfamilymap.yaml" as osfamilymap %}
  File "/usr/lib/python3.9/site-packages/jinja2/environment.py", line 1155, in make_module
    return TemplateModule(self, self.new_context(vars, shared, locals))
  File "/usr/lib/python3.9/site-packages/jinja2/environment.py", line 1238, in __init__
    body_stream = list(template.root_render_func(context))
  File "/var/cache/salt/minion/files/base/postgres/osfamilymap.yaml", line 66, in top-level template code
    {%- if grains.get('osmajorrelease') >= 7 %}
TypeError: '>=' not supported between instances of 'NoneType' and 'int'

```
### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->