### PR TITLE
fix(centOS): postgres11 needs libicu installed

### DIFF
--- a/postgres/osfamilymap.yaml
+++ b/postgres/osfamilymap.yaml
@@ -64,6 +64,8 @@ RedHat:
     baseurl: 'https://download.postgresql.org/pub/repos/yum/{{ repo.version }}/redhat/rhel-$releasever-$basearch'
 
 {%- if grains.get('osmajorrelease', 0) >= 7 %}
+  pkgs_deps:
+    - libicu
   pkg_python: python3-psycopg2
 {%- endif %}
 


### PR DESCRIPTION
### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [x] Changes to documentation are appropriate (or tick if not required)
- [x] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

Install `libicu `on centOS

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->

Error
```
[ERROR   ] Command '['systemd-run', '--scope', 'yum', '-y', '--disablerepo=*', '--enablerepo=pgdg11', 'install', 'postgresql11-server']' failed with return code: 1
[ERROR   ] stdout: Running scope as unit run-40351.scope.
Resolving Dependencies
--> Running transaction check
---> Package postgresql11-server.x86_64 0:11.10-1PGDG.rhel7 will be installed
--> Processing Dependency: postgresql11-libs(x86-64) = 11.10-1PGDG.rhel7 for package: postgresql11-server-11.10-1PGDG.rhel7.x86_64
--> Processing Dependency: postgresql11(x86-64) = 11.10-1PGDG.rhel7 for package: postgresql11-server-11.10-1PGDG.rhel7.x86_64
--> Processing Dependency: libicuuc.so.50()(64bit) for package: postgresql11-server-11.10-1PGDG.rhel7.x86_64
--> Processing Dependency: libicui18n.so.50()(64bit) for package: postgresql11-server-11.10-1PGDG.rhel7.x86_64
--> Running transaction check
---> Package postgresql11.x86_64 0:11.10-1PGDG.rhel7 will be installed
--> Processing Dependency: libicu for package: postgresql11-11.10-1PGDG.rhel7.x86_64
---> Package postgresql11-libs.x86_64 0:11.10-1PGDG.rhel7 will be installed
---> Package postgresql11-server.x86_64 0:11.10-1PGDG.rhel7 will be installed
--> Processing Dependency: libicuuc.so.50()(64bit) for package: postgresql11-server-11.10-1PGDG.rhel7.x86_64
--> Processing Dependency: libicui18n.so.50()(64bit) for package: postgresql11-server-11.10-1PGDG.rhel7.x86_64
--> Finished Dependency Resolution
Error: Package: postgresql11-server-11.10-1PGDG.rhel7.x86_64 (pgdg11)
           Requires: libicuuc.so.50()(64bit)
Error: Package: postgresql11-11.10-1PGDG.rhel7.x86_64 (pgdg11)
           Requires: libicu
Error: Package: postgresql11-server-11.10-1PGDG.rhel7.x86_64 (pgdg11)
           Requires: libicui18n.so.50()(64bit)
 You could try using --skip-broken to work around the problem
** Found 2 pre-existing rpmdb problem(s), 'yum check' output follows:
rpm-libs-4.11.3-40.el7.x86_64 has missing requires of rpm = ('0', '4.11.3', '40.el7')
rpm-python-4.11.3-40.el7.x86_64 has missing requires of rpm = ('0', '4.11.3', '40.el7')
[ERROR   ] retcode: 1
[ERROR   ] Error occurred installing package(s). Additional info follows:
errors:
    - Running scope as unit run-40351.scope.
      Resolving Dependencies
      --> Running transaction check
11:53
---> Package postgresql11-server.x86_64 0:11.10-1PGDG.rhel7 will be installed
      --> Processing Dependency: postgresql11-libs(x86-64) = 11.10-1PGDG.rhel7 for package: postgresql11-server-11.10-1PGDG.rhel7.x86_64
      --> Processing Dependency: postgresql11(x86-64) = 11.10-1PGDG.rhel7 for package: postgresql11-server-11.10-1PGDG.rhel7.x86_64
      --> Processing Dependency: libicuuc.so.50()(64bit) for package: postgresql11-server-11.10-1PGDG.rhel7.x86_64
      --> Processing Dependency: libicui18n.so.50()(64bit) for package: postgresql11-server-11.10-1PGDG.rhel7.x86_64
      --> Running transaction check
      ---> Package postgresql11.x86_64 0:11.10-1PGDG.rhel7 will be installed
      --> Processing Dependency: libicu for package: postgresql11-11.10-1PGDG.rhel7.x86_64
      ---> Package postgresql11-libs.x86_64 0:11.10-1PGDG.rhel7 will be installed
      ---> Package postgresql11-server.x86_64 0:11.10-1PGDG.rhel7 will be installed
      --> Processing Dependency: libicuuc.so.50()(64bit) for package: postgresql11-server-11.10-1PGDG.rhel7.x86_64
      --> Processing Dependency: libicui18n.so.50()(64bit) for package: postgresql11-server-11.10-1PGDG.rhel7.x86_64
      --> Finished Dependency Resolution
      Error: Package: postgresql11-server-11.10-1PGDG.rhel7.x86_64 (pgdg11)
                 Requires: libicuuc.so.50()(64bit)
      Error: Package: postgresql11-11.10-1PGDG.rhel7.x86_64 (pgdg11)
                 Requires: libicu
      Error: Package: postgresql11-server-11.10-1PGDG.rhel7.x86_64 (pgdg11)
                 Requires: libicui18n.so.50()(64bit)
       You could try using --skip-broken to work around the problem
      ** Found 2 pre-existing rpmdb problem(s), 'yum check' output follows:
      rpm-libs-4.11.3-40.el7.x86_64 has missing requires of rpm = ('0', '4.11.3', '40.el7')
      rpm-python-4.11.3-40.el7.x86_64 has missing requires of rpm = ('0', '4.11.3', '40.el7')
[ERROR   ] User postgres is not available Group postgres is not available
[ERROR   ] Command '['systemd-run', '--scope', 'yum', '-y', '--disablerepo=*', '--enablerepo=pgdg11', 'install', 'postgresql11']' failed with return code: 1
[ERROR   ] stdout: Running scope as unit run-40359.scope.
Resolving Dependencies
--> Running transaction check
---> Package postgresql11.x86_64 0:11.10-1PGDG.rhel7 will be installed
--> Processing Dependency: postgresql11-libs(x86-64) = 11.10-1PGDG.rhel7 for package: postgresql11-11.10-1PGDG.rhel7.x86_64
--> Processing Dependency: libicu for package: postgresql11-11.10-1PGDG.rhel7.x86_64
--> Running transaction check
---> Package postgresql11.x86_64 0:11.10-1PGDG.rhel7 will be installed
--> Processing Dependency: libicu for package: postgresql11-11.10-1PGDG.rhel7.x86_64
---> Package postgresql11-libs.x86_64 0:11.10-1PGDG.rhel7 will be installed
--> Finished Dependency Resolution
Error: Package: postgresql11-11.10-1PGDG.rhel7.x86_64 (pgdg11)
           Requires: libicu
 You could try using --skip-broken to work around the problem
** Found 2 pre-existing rpmdb problem(s), 'yum check' output follows:
rpm-libs-4.11.3-40.el7.x86_64 has missing requires of rpm = ('0', '4.11.3', '40.el7')
rpm-python-4.11.3-40.el7.x86_64 has missing requires of rpm = ('0', '4.11.3', '40.el7')
[ERROR   ] retcode: 1
[ERROR   ] Error occurred installing package(s). Additional info follows:
errors:
    - Running scope as unit run-40359.scope.
      Resolving Dependencies
      --> Running transaction check
      ---> Package postgresql11.x86_64 0:11.10-1PGDG.rhel7 will be installed
      --> Processing Dependency: postgresql11-libs(x86-64) = 11.10-1PGDG.rhel7 for package: postgresql11-11.10-1PGDG.rhel7.x86_64
      --> Processing Dependency: libicu for package: postgresql11-11.10-1PGDG.rhel7.x86_64
      --> Running transaction check
      ---> Package postgresql11.x86_64 0:11.10-1PGDG.rhel7 will be installed
11:54
You could try using --skip-broken to work around the problem
** Found 2 pre-existing rpmdb problem(s), 'yum check' output follows:
rpm-libs-4.11.3-40.el7.x86_64 has missing requires of rpm = ('0', '4.11.3', '40.el7')
rpm-python-4.11.3-40.el7.x86_64 has missing requires of rpm = ('0', '4.11.3', '40.el7')
[ERROR   ] retcode: 1
[ERROR   ] Error occurred installing package(s). Additional info follows:
errors:
    - Running scope as unit run-40359.scope.
      Resolving Dependencies
      --> Running transaction check
      ---> Package postgresql11.x86_64 0:11.10-1PGDG.rhel7 will be installed
      --> Processing Dependency: postgresql11-libs(x86-64) = 11.10-1PGDG.rhel7 for package: postgresql11-11.10-1PGDG.rhel7.x86_64
      --> Processing Dependency: libicu for package: postgresql11-11.10-1PGDG.rhel7.x86_64
      --> Running transaction check
      ---> Package postgresql11.x86_64 0:11.10-1PGDG.rhel7 will be installed
      --> Processing Dependency: libicu for package: postgresql11-11.10-1PGDG.rhel7.x86_64
      ---> Package postgresql11-libs.x86_64 0:11.10-1PGDG.rhel7 will be installed
      --> Finished Dependency Resolution
      Error: Package: postgresql11-11.10-1PGDG.rhel7.x86_64 (pgdg11)
                 Requires: libicu
       You could try using --skip-broken to work around the problem
      ** Found 2 pre-existing rpmdb problem(s), 'yum check' output follows:
      rpm-libs-4.11.3-40.el7.x86_64 has missing requires of rpm = ('0', '4.11.3', '40.el7')
      rpm-python-4.11.3-40.el7.x86_64 has missing requires of rpm = ('0', '4.11.3', '40.el7')
[ERROR   ] State 'postgres_user.present' was not found in SLS 'postgres.manage'
```

