### PR TITLE
fix(osmap.yaml): fix PGDG repo file creation for Amazon Linux 2

### DIFF
--- a/postgres/osmap.yaml
+++ b/postgres/osmap.yaml
@@ -9,3 +9,7 @@ Fedora:
     baseurl: 'https://download.postgresql.org/pub/repos/yum/{{ repo.version }}/fedora/fedora-$releasever-$basearch'
   remove:
     releases: ['9.4', '9.5', '9.6', '10']
+
+Amazon:
+  pkg_repo:
+    baseurl: 'https://download.postgresql.org/pub/repos/yum/{{ repo.version }}/redhat/rhel-7-$basearch'


### PR DESCRIPTION
Fix improper pgdg repo file creation for Amazon Linux 2.

Description:
Current formula implementation uses 
`baseurl: 'https://download.postgresql.org/pub/repos/yum/{{ repo.version }}/redhat/rhel-$releasever-$basearch'`
setting $releasever to 2 for Amazon Linux 2 and making formula install fail due to missing rhel-2 packages.

The fix makes a newly created formula repo file to use rhel-7 as the proper repository to use during install.