### PR TITLE
feat(debian): add bullseye support

### DIFF
--- a/postgres/codenamemap.yaml
+++ b/postgres/codenamemap.yaml
@@ -60,12 +60,14 @@
 {{ debian_codename('jessie', '9.4') }}
 {{ debian_codename('stretch', '9.6') }}
 {{ debian_codename('buster', '11') }}
+{{ debian_codename('bullseye', '13') }}
 
 # `oscodename` grain has long distro name
 # if `lsb-release` package not installed
 {{ debian_codename('jessie', '9.4', 'Debian GNU/Linux 8 (jessie)') }}
 {{ debian_codename('stretch', '9.6', 'Debian GNU/Linux 9 (stretch)') }}
 {{ debian_codename('buster', '11', 'Debian GNU/Linux 10 (buster)') }}
+{{ debian_codename('bullseye', '13', 'Debian GNU/Linux 11 (bullseye)') }}
 
 ## Ubuntu
 # http://apt.postgresql.org/pub/repos/apt/dists/


### PR DESCRIPTION

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->

N/A. No one has documented an attempt to run this formula on debian bullseye (testing) at this stage.

### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

Hi there. Currently, installation on debian bullseye results in a broken APT configuration if `use_upstream_repo` is set to True. The string "postgresql-repo" string is entered into the `/etc/apt/sources.list.d/pgdg.list` file. This results in apt being unusable in the target system, which ideally should not happen.

My changes resolve this issue by adding support for debian bullseye (testing)

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

```
postgres:
  use_upstream_repo: True
  fromrepo: bullseye-pgdg
  version: '13'
```

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

```
root@saltmain:/srv/formulas# salt 'unicornbottle-main' state.apply postgres.upstream
unicornbottle-main:
  Name: postgresql-pkg-deps - Function: pkg.installed - Result: Clean Started: - 15:21:26.534113 Duration: 23.875 ms
  Name: deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main - Function: pkgrepo.managed - Result: Changed Started: - 15:21:26.559226 Duration: 6556.887 ms

Summary for unicornbottle-main
------------
Succeeded: 2 (changed=1)
Failed:    0
------------
Total states run:     2
Total run time:   6.581 s
```

Now configuration is set as follows:

```
# cat /etc/apt/sources.list.d/pgdg.list
deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main
```

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [x] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->

This is debian's unstable branch. I'm personally using it to be a little more up to date as stability is not a concern for my current project. If I have any issues I'll update here with additional fixes, however I think that how the project is laid out everything should continue to work as this is a very small change which should not have many repercussions.

